### PR TITLE
markdown to CSV conversion (as input for Algolia)

### DIFF
--- a/content/markdown_conversion.py
+++ b/content/markdown_conversion.py
@@ -1,4 +1,4 @@
-import re, os, json
+import re, os, json, pandas as pd
 
 def list_files(filepath, filetype):
     paths = []
@@ -50,15 +50,11 @@ def export_data(file_paths):
             json_data.append(structure_markdown(df, path))
         except:
             print(path) # skipped files
-    
-    with open('markdown_conversion.json', 'w') as fp:
-        json.dump(json_data, fp)
+    return json_data
 
     
 # generate list of all markdown files
 file_paths = list_files(".", ".md")
-export_data(file_paths)
-
-        
-        
-
+json_data = export_data(file_paths)
+df = pd.DataFrame(json_data)
+df.to_csv("markdown_conversion.csv", index=False)

--- a/content/markdown_conversion.py
+++ b/content/markdown_conversion.py
@@ -1,0 +1,64 @@
+import re, os, json
+
+def list_files(filepath, filetype):
+    paths = []
+    for root, dirs, files in os.walk(filepath):
+        for file in files:
+            if file.lower().endswith(filetype.lower()):
+                paths.append(os.path.join(root, file))
+    return(paths)
+
+
+def search_item(word, header):
+    r = re.compile(word)
+    content = list(filter(r.match, header))[0]
+    content = content[len(word) + 2:]
+    return content.strip('"').strip("'")
+
+def structure_markdown(df, path):
+    # split markdown in header and body
+    max_index = df[1:].index('---') + 1
+    header = df[1:max_index]
+    body_list = df[max_index + 1:]
+    body = " ".join(body_list)
+
+    # define regular expression patterns
+    code_block = re.compile("{{% codeblock %}}(.+?){{% /codeblock %}}")
+    headers = re.compile("#{2,6}\s(.+)")
+
+    # separate code, headers, and content
+    body_no_code = re.sub(code_block, "", body)
+    body_no_headers = " ".join([word for word in body_list if not re.search(headers, word)])
+    
+    return {
+        "file": path,
+        "title": search_item("title", header),
+        "description": search_item("description", header),
+        "keywords": search_item("keywords", header),
+        "code": re.findall(code_block, body),
+        "headers": [re.search(headers, word).group(1) for word in body_list if re.search(headers, word)],
+        "content": re.sub(code_block, "", body_no_headers)
+    }
+
+def export_data(file_paths):
+    json_data = []
+
+    for path in file_paths:
+        f = open(path, 'r')
+        df = f.read().split('\n')
+        try: 
+            json_data.append(structure_markdown(df, path))
+        except:
+            print(path) # skipped files
+    
+    with open('markdown_conversion.json', 'w') as fp:
+        json.dump(json_data, fp)
+
+    
+# generate list of all markdown files
+file_paths = list_files(".", ".md")
+export_data(file_paths)
+
+        
+        
+


### PR DESCRIPTION
Run `python markdown_conversion.py` to convert all building blocks, tutorial, and example markdown files into a single CSV file. Each record in the dictionary contains the following keys: file path, title, description, keywords, code, headers, and content (i.e., markdown content without the meta-data, code blocks, and headers). 

Note that the script processes all markdown files within the current directory (so if you move the file somewhere else you need to update the file paths).