### PR TITLE
Fixed search errors for tutorials

### DIFF
--- a/content/tutorials/code-like-a-pro/hugo-website/hugo-website-overview.md
+++ b/content/tutorials/code-like-a-pro/hugo-website/hugo-website-overview.md
@@ -14,6 +14,7 @@ aliases:
   - /launch/hugo-website
   - /create/personal-website
   - /tutorials/open-education/hugo-website/hugo-website-overview/
+  - /tutorials/code-like-a-pro/hugo-website/_index
 ---
 
 ## Why to Launch a Website?

--- a/content/tutorials/code-like-a-pro/online-data-collection-and-management/odcm-course.md
+++ b/content/tutorials/code-like-a-pro/online-data-collection-and-management/odcm-course.md
@@ -10,6 +10,7 @@ draft: false
 aliases:
   - /tutorial/odcm
   - /tutorials/open-education/online-data-collection-and-management/odcm-course
+  - /tutorials/code-like-a-pro/online-data-collection-and-management/_index
 ---
 
 ## Overview

--- a/content/tutorials/code-like-a-pro/web-scraping/web-scraping-tutorial.md
+++ b/content/tutorials/code-like-a-pro/web-scraping/web-scraping-tutorial.md
@@ -1,7 +1,7 @@
 ---
 tutorialtitle: "Web Scraping and API Mining"
 type: "web-scraping"
-title: "Collect data from the web and API"
+title: "Web Scraping and API Mining"
 description: "Learn to extract data from the web and APIs"
 keywords: "scrape, webscraping, internet, beautifulsoup, static website, dynamic website, website, api, application programming interface"
 weight: 1

--- a/content/tutorials/more-tutorials/educational-videos/educational-videos-overview.md
+++ b/content/tutorials/more-tutorials/educational-videos/educational-videos-overview.md
@@ -12,6 +12,7 @@ authorlink: "https://www.tilburguniversity.edu/staff/a-d-antonacci"
 aliases:
   - /learn/educational-videos
   - /tutorials/open-education/educational-videos/educational-videos-overview
+  - /tutorials/more-tutorials/educational-videos/_index
 ---
 
 ## What is an educational video?

--- a/content/tutorials/more-tutorials/write-an-academic-paper/write-an-academic-paper.md
+++ b/content/tutorials/more-tutorials/write-an-academic-paper/write-an-academic-paper.md
@@ -10,6 +10,7 @@ draft: false
 aliases:
   - /write/academic-paper
   - /tutorials/more-tutorials/write-an-academic-paper/write-an-academic-paper
+  - /tutorials/more-tutorials/write-an-academic-paper/_index
 ---
 
 ## Overview

--- a/content/tutorials/more-tutorials/write-your-first-latex-document/what-is-latex.md
+++ b/content/tutorials/more-tutorials/write-your-first-latex-document/what-is-latex.md
@@ -8,6 +8,7 @@ weight: 100
 draft: false
 aliases:
   - /learn/latex
+  - /tutorials/more-tutorials/write-your-first-latex-document/_index
 
 ---
 

--- a/content/tutorials/reproducible-research-and-automation/data-preparation-and-workflow-management/dprep-course.md
+++ b/content/tutorials/reproducible-research-and-automation/data-preparation-and-workflow-management/dprep-course.md
@@ -10,6 +10,7 @@ draft: false
 aliases:
   - /tutorial/dprep
   - /tutorials/open-education/data-preparation-and-workflow-management/dprep-course/
+  - /tutorials/reproducible-research-and-automation/data-preparation-and-workflow-management/_index
 
 ---
 

--- a/content/tutorials/reproducible-research-and-automation/practicing-pipeline-automation-make/pipeline-automation-overview.md
+++ b/content/tutorials/reproducible-research-and-automation/practicing-pipeline-automation-make/pipeline-automation-overview.md
@@ -10,6 +10,7 @@ weight: 1
 aliases:
   - /practice/pipeline-automation
   - /tutorials/reproducible-research/practicing-pipeline-automation-make/pipeline-automation-overview
+  - /tutorials/reproducible-research-and-automation/practicing-pipeline-automation-make/_index
 ---
 
 Longing to put your knowledge from our [workflow guide](/tutorials/project-management/principles-of-project-setup-and-workflow-management/overview/) into practice? Then follow this tutorial to implement a fully automated workflow to conduct sentiment analysis on tweets, using our [GitHub workflow template](https://github.com/hannesdatta/textmining-workflow).

--- a/content/tutorials/reproducible-research-and-automation/principles-of-project-setup-and-workflow-management/project-setup-overview.md
+++ b/content/tutorials/reproducible-research-and-automation/principles-of-project-setup-and-workflow-management/project-setup-overview.md
@@ -10,6 +10,7 @@ weight: 1
 aliases:
   - /learn/project-setup
   - /tutorials/project-management/principles-of-project-setup-and-workflow-management/project-setup-overview
+  - /tutorials/reproducible-research-and-automation/principles-of-project-setup-and-workflow-management/_index
 ---
 
 ## Motivation

--- a/content/tutorials/reproducible-research-and-automation/share-data/share-data.md
+++ b/content/tutorials/reproducible-research-and-automation/share-data/share-data.md
@@ -8,6 +8,7 @@ draft: false
 aliases:
   - /share/data
   - /tutorials/reproducible-research/share-data/share-data
+  - /tutorials/reproducible-research-and-automation/share-data/_index
 ---
 
 ## Overview

--- a/content/tutorials/reproducible-research-and-automation/start-new-project/starting-up-a-new-project.md
+++ b/content/tutorials/reproducible-research-and-automation/start-new-project/starting-up-a-new-project.md
@@ -9,6 +9,7 @@ draft: false
 aliases:
   - /start/new-project
   - /tutorials/reproducible-research/start-new-project/starting-up-a-new-project
+  - /tutorials/reproducible-research-and-automation/start-new-project/_index
 ---
 
 When working on a new project, it's efficient to kick-start your work with a well-documented "repository template" that sets up your workflow, and provides you with some minimal documentation so that team members can quickly contribute to your work.

--- a/content/tutorials/scale-up/running-computations-remotely/cloud-computing.md
+++ b/content/tutorials/scale-up/running-computations-remotely/cloud-computing.md
@@ -9,6 +9,7 @@ draft: false
 aliases:
   - /learn/cloud
   - /tutorials/more-tutorials/running-computations-remotely/cloud-computing
+  - /tutorials/scale-up/running-computations-remotely/_index
   
 ---
 

--- a/content/tutorials/scale-up/scrum-for-researchers/use-scrum-in-your-team.md
+++ b/content/tutorials/scale-up/scrum-for-researchers/use-scrum-in-your-team.md
@@ -13,6 +13,7 @@ aliases:
   - /professionalize/teamwork
   - /learn/teamwork
   - /tutorials/project-management/scrum-for-researchers/use-scrum-in-your-team
+  - /tutorials/scale-up/scrum-for-researchers/_index
 ---
 
 ## How we professionalized our team work


### PR DESCRIPTION
The search bar refurred to the index page (/tutorials/scale-up/scrum-for-researchers/_index) instead of the overview page causing an error. Therefore, I added the _index to the alliases.