### PR TITLE
Removed the main image above the fold for mobile

### DIFF
--- a/themes/tilburg/assets/scss/_images.scss
+++ b/themes/tilburg/assets/scss/_images.scss
@@ -40,3 +40,11 @@
   @include font-size($figure-caption-font-size);
   color: $figure-caption-color;
 }
+
+
+//added a class which removes div's when the screen is smaller than 600px class="mobremove"
+@media screen and (max-width: 600px) {
+  div.mobremove {
+    display: none;
+  }
+}

--- a/themes/tilburg/layouts/index.html
+++ b/themes/tilburg/layouts/index.html
@@ -131,8 +131,8 @@
 
 end of search on homepage feature -->
 
-		<div class="col-lg-6 mt-3 col-16 order-1 order-lg-2 text-center">
-      <img src="/img/hero.svg" class="hero-image mx-auto mx-lg-none" style="max-width: 300px;" >
+		<div class="col-lg-6 mt-3 col-16 order-1 order-lg-2 text-center mobremove">
+      <img src="/img/hero.svg" class="hero-image mx-auto mx-lg-none" >
     </div>
 
 


### PR DESCRIPTION
Added a new css element called mobremove, which removes div's for phone screens. With this removed the homepage image for mobile phones.