### PR TITLE
Update configuring-python-for-webscraping.md

### DIFF
--- a/content/building-blocks/configure-your-computer/task-specific-configurations/configuring-python-for-webscraping.md
+++ b/content/building-blocks/configure-your-computer/task-specific-configurations/configuring-python-for-webscraping.md
@@ -125,7 +125,7 @@ Sometimes, `brew doctor` returns some warnings. While it's advisable to fix them
 *   Install `chromedriver` via Homebrew:
 
 ```
-brew cask install chromedriver
+brew install chromedriver --cask
 ```
 
 *   Verify your install, by entering the following in your terminal. The expected output is `ChromeDriver XX`


### PR DESCRIPTION
code has changed which is used for installing chromedriver through homebrew (I think this is the same for other packages/programs we install through homebrew, but I am not sure)