### PR TITLE
Missing tutorial on Airbnb workflow

### DIFF
--- a/content/tutorials/more-tutorials/airbnb-workflow/_index.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Inside AirBnB - Workflow Walkthrough"
 date: 2020-11-11T22:01:14+05:30
-draft: true
+draft: false
 weight: 4
 indexPage: "airbnb-workflow-overview"
 description: "Set up an end-to-end workflow to investigate the impact of COVID-19 on AirBnB bookings"

--- a/content/tutorials/more-tutorials/airbnb-workflow/airbnb-workflow-overview.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/airbnb-workflow-overview.md
@@ -5,16 +5,16 @@ title: "Overview"
 description: "Set up an end-to-end workflow to investigate the impact of COVID-19 on AirBnB bookings"
 keywords: "airbnb, make, R, workflow, inside airbnb, walkthrough"
 date: 2021-01-06T22:01:14+05:30
-draft: true
+draft: false
 weight: 10
 ---
 
 # Overview
 
 ## Inside AirBnB
-[Inside Airbnb](http://insideairbnb.com/index.html) is an independent open-source data tool developed by community activist Murray Cox who aims to shed light on how Airbnb is being used and affecting neighborhoods in large cities. The tool provides a visual overview of the amount. availability, and spread of rooms across a city, an approximation of the number of bookings and occupancy rate, and the number of listings per host.
+[Inside Airbnb](http://insideairbnb.com/index.html) is an independent open-source data tool developed by community activist Murray Cox who aims to shed light on how Airbnb is being used and affecting neighborhoods in large cities. The tool provides a visual overview of the amount, availability, and spread of rooms across a city, an approximation of the number of bookings and occupancy rate, and the number of listings per host.
 
-For example, [here](http://insideairbnb.com/amsterdam/) is the dashboard for the city of Amsterdam which shows us that 79% of the 19,619 listings are entire homes of which about a quarter is available all year round. Moreover, the animation below illustrates how the number of listings have been growing rapidly throughout the years:
+For example, [here](http://insideairbnb.com/amsterdam/) is the dashboard for the city of Amsterdam. The animation below illustrates how the number of listings have been growing rapidly throughout the years:
 
 ![title](../images/airbnb_expansion.gif)
 

--- a/content/tutorials/more-tutorials/airbnb-workflow/automating_workflows.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/automating_workflows.md
@@ -5,7 +5,7 @@ indexexclude: "true"
 weight: 50
 title: "Automating Workflows"
 date: 2021-01-06T22:01:14+05:30
-draft: true
+draft: false
 ---
 
 # Automating Workflows
@@ -36,7 +36,7 @@ Revisit the [study notes](/automate/project-setup) on *"Automating your Pipeline
 
 
 **Exercise**     
-Swap the `url_listings` and `url_reviews` for a historical dataset of Amsterdam from the year 2016 (gather the links from the "[show archived page](http://insideairbnb.com/get-the-data.html)"). Run `make` again in the root directory.
+Swap the `url_listings` and `url_reviews` for a historical dataset of Amsterdam from the previous year (gather the links from the "[show archived page](http://insideairbnb.com/get-the-data.html)"). Run `make` again in the root directory.
 
 
 Do the same for a recent Airbnb dataset from New York.  If done correctly, it should not take more than a minute (power to automation!). Do your workflows still run as expected? How about the `plot_Amsterdam.R` file? Why is that?

--- a/content/tutorials/more-tutorials/airbnb-workflow/conclusion.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/conclusion.md
@@ -5,13 +5,23 @@ indexexclude: "true"
 weight: 60
 title: "Conclusion"
 date: 2021-01-06T22:01:14+05:30
-draft: true
+draft: false
 ---
 
 # Conclusion
-Study the output files and formulate an answer to our initial research question as well as the following subquestions:
+In this tutorial, we explored how to leverage Inside Airbnb data to analyze the impact of the COVID-19 pandemic on the Airbnb market in Amsterdam. We walked through the step-by-step process of downloading, cleaning, transforming, and visualizing the data, enabling us to gain insights into reviews per neighborhood.
 
+**Final exercise**: Study the output files and formulate an answer to our initial research question as well as the following subquestions.
+
+**Main Research Question:** _How did the Airbnb market in Amsterdam respond to the COVID-19 pandemic in terms of bookings per neighborhood?_
+
+**Subquestions**:
 * Did all neighbourhoods in Amsterdam suffer equally from the pandemic?
 * Why is the number of listings in December 2020 remarkably low?
 * Discuss the methods you can use to test whether the identified relationship is statistically significant. How would you define the regression model? (no need to implement it here!)
 * Comment on the limitations of our approach and come up with strategies to overcome them.
+
+
+{{% example %}}
+To supplement this tutorial, we have developed a [**GitHub repository**](https://github.com/tilburgsciencehub/inside-airbnb-tutorial) that includes the complete code necessary to replicate our findings on analyzing the impact of COVID-19 on the Airbnb market in Amsterdam using Inside Airbnb data. This allows you to compare our approach with your own and gain insights for further analysis. Happy exploring!
+{{% /example %}}

--- a/content/tutorials/more-tutorials/airbnb-workflow/exporting_data.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/exporting_data.md
@@ -5,7 +5,7 @@ indexexclude: "true"
 weight: 40
 title: "Exporting the Data"
 date: 2021-01-06T22:01:14+05:30
-draft: true
+draft: false
 ---
 
 # Exporting Data
@@ -17,7 +17,7 @@ A time-series plot that shows the total number of reviews over time (across all 
 
 * Import the data from `gen/data-preparation/aggregated_df.csv`
 * Convert the `date` column into date format.
-* Group by date and calculate the sum of all reviews across neighourhoods.
+* Group by date and calculate the sum of all reviews across neighborhoods.
 * Plot the chart and store the visualisation.
 
 ![](../images/plot_all.png)

--- a/content/tutorials/more-tutorials/airbnb-workflow/loading_data.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/loading_data.md
@@ -5,7 +5,7 @@ indexexclude: "true"
 weight: 20
 title: "Loading the Data"
 date: 2021-01-06T22:01:14+05:30
-draft: true
+draft: false
 ---
 
 # Loading the Data
@@ -16,14 +16,14 @@ The [data](http://insideairbnb.com/get-the-data.html) underlying Inside Airbnb h
 Information about the host, location, room type, price, reviews, and availability.
 
 *Reviews*  
-The listing ID and the date of the review. More details about the review such as the comment and author can be `reviews.csv.gz.` file but is outside the scope of this tutorial.
+The listing ID and the date of the review. More details about the review such as the comment and author can be seen in the `reviews.csv.gz` file, but it is beyond the scope of this tutorial.
 
 **Exercise**     
 Before we fully automate our workflows, it is imperative to have a close look at the data.
 
-1. Set up a directory structure in accordance with these [guidelines](http://tilburgsciencehub.com/workflow/directories/). It should have a `data`, `gen`, and `src` directory and a `data-preparation` subdirectory in `src` and `gen`.
-2. Manually download the most recent version of `listings.csv` and `reviews.csv` listed on [Inside Airbnb](http://insideairbnb.com/get-the-data.html) and store them in the `data` folder.
-3. Create a data report (like you did in Data Challenge 1) .  
+1. Set up a directory structure in accordance with this [template](https://github.com/rgreminger/example-make-workflow). It should have a `data`, `gen`, and `src` directory and a `data-preparation` subdirectory in `src` and `gen`.
+2. Manually download the most recent version of `listings.csv` and `reviews.csv` listed on [Inside Airbnb](http://insideairbnb.com/get-the-data.html) for Amsterdam and store them in the `data` folder.
+3. Create a data report:  
   * Read the data into R and generate an overview of the data (e.g., summary statistics, report on missingness, number of observations, etc.).
   * Explore interesting relationships in the data.
 
@@ -56,7 +56,7 @@ Say that you want to share your work with others, you could essentially give the
 ```
 download.file(url = url, destfile = filename)
 ```
-4. Run the R script from the command line and test whether it works as expected. First, type `R` in the command line (e.g., Terminal on Mac) and see whether it opens the R command line. If not, you may need to configure a path to the R library as described [here](https://stackoverflow.com/questions/44336345/running-r-from-mac-osx-terminal). Next, run the command below to run the download.R script from the terminal. It downloads the data from Inside Airbnb and stores it into the `data` directory.
+4. Run the R script from the command line and test whether it works as expected. Make sure to open the command line in the folder with the script.  First, type `R` in the command line (e.g., Terminal on Mac or Command Prompt on Windows) and see whether it opens the R command line. If not, you may need to configure a path to the R library as described [here](/building-blocks/configure-your-computer/statistics-and-computation/r/). Next, run the command below to run the download.R script from the terminal. It downloads the data from Inside Airbnb and stores it into the `data` directory.
 
 ```
 R < download.R --save

--- a/content/tutorials/more-tutorials/airbnb-workflow/transforming_data.md
+++ b/content/tutorials/more-tutorials/airbnb-workflow/transforming_data.md
@@ -5,7 +5,7 @@ indexexclude: "true"
 weight: 30
 title: "Transforming the Data"
 date: 2021-01-06T22:01:14+05:30
-draft: true
+draft: false
 ---
 
 # Transforming Data
@@ -45,11 +45,11 @@ Create a file `clean.R` that loads the data from the `data` directory and reshap
 Please adhere to the step-by-step guidelines below:  
 
 * Convert the date column of `reviews` into date/time format.
-* Filter for `reviews` published since January 1st 2015
+* Filter for `reviews` published since January 1st 2015.
 * Filter for `listings` that have received at least 1 review.
 * Merge the `reviews` and `listings` dataframes on a common column.
 * Group the number of reviews by date and neighborhood (aggregated on a monthly level).
-* Store the final data frames in `gen/data-preparation` as `aggregated_df.csv`
+* Store the final data frames in `gen/data-preparation` as `aggregated_df.csv`.
 
 
 ## Reshaping Data
@@ -66,4 +66,4 @@ If we want to compare neighbourhoods side by side (e.g., Centrum-West vs De Pijp
 ---
 
 
-Import the data from `gen/data-preparatin/aggregated_df.csv`, reshape the data into wide format and store the result as `pivot_table.csv` in `gen/data-preparation`.
+Import the data from `gen/data-preparation/aggregated_df.csv`, reshape the data into wide format and store the result as `pivot_table.csv` in `gen/data-preparation`.


### PR DESCRIPTION
Related to issue #650

The tutorial was finished but set as a draft, and therefore, not visible on the website.
I made some minor changes (updated links etc.) and added a repository with solutions in the conclusions (https://github.com/tilburgsciencehub/inside-airbnb-tutorial), where I followed the steps described in the tutorial.

I didn't update e.g. the charts in the tutorial itself because, with time, these will always get outdated.