### PR TITLE
[content update] 743-import-python-env-in-gcp

### DIFF
--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -187,7 +187,7 @@ Now you should go back to the Google cloud console and click the button "Set up 
 
 {{% warning %}}
 
-In point three of the steps listed above you are told to introduce "0.0.0.0/0" in the field "Source IPv4 ranges". Beware that what this means is that your instance will allow connections from any external IP (i.e. any other computer). If you are concerned about the safety risk this involves and/or you know beforehand the list of IP addresses that you want to allow to connect to your instance, you could list them here instead of typing the one-size-fits-all "0.0.0.0/0".
+In point three of the steps listed above you are told to introduce "0.0.0.0/0" in the field "Source IPv4 ranges". Beware this means that your instance will allow connections from any external IP (i.e. any other computer). If you are concerned about the safety risk this involves and/or you know beforehand the list of IP addresses that you want to allow to connect to your instance, you could list them here instead of typing the one-size-fits-all "0.0.0.0/0".
 
 {{% /warning %}}
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -13,127 +13,59 @@ aliases:
 
 ---
 
-# Import and run a Python environment on Google cloud with Docker
+## Import and run a Python environment on Google cloud with Docker
 
 Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn how to replicate a Python environment from a project on an existing Google cloud instance using Docker and then open Jupyter notebook on it. Additionally, you will also learn how to connect your replicated environment directly to Google Cloud storage buckets to comfortably save and share your output. 
 
 {{% warning %}}
 
+DISCLAIMER HERE - WORK ALONGSIDE PREVIOUS BB
+
 To be able to follow this building block you will need that the project you want to import already provides both  a dockerfile and a docker-compose.yml file, with the adequate information to run the latter.
 
 {{% /warning %}}
 
-### Step 1: Install and Set up Docker in a Google cloud instance
+### Step 1: Install and Set up Docker in your Google cloud instance
 
-The first thing you need to consider  to install Docker in your instance is which boot disk image is it using. You can check a detailed version of the installation procedure in [the official Docker documentation](https://docs.docker.com/engine/install/debian/), where you will find instructions for installing Docker on all supported Linux distributions and operative systems through the command line. If on the contrary, you prefer to cut it straight to the chase, you can simply execute one by one the code lines below on your instance's command line to get Docker installed. These cover the installation of Docker for Ubuntu and Debian boot disk images. The instructions for these two Linux distributions are essentially the same except for steps #5 and #6 which have been duplicated to cover both, you have to pick the one that adjusts to your case.
+Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedures for Linux-based systems. You can learn how to do so by visiting our building block on how to [Set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS and Ubuntu Linux.
 
+For those who prefer a more streamlined approach, we have condensed these instruction into two Docker installation scripts available for download below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step or directly upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with this building block!
 
-{{% tip %}}
+{{% cta-primary-center "Download script for installing Docker in Debian Linux" "https://raw.githubusercontent.com/social-science-data-editors/template_README/releases/README.md" %}}
 
-While Debian is the default boot disk image in Google cloud instances, we recommend the usage of a Ubuntu image if you are including a GPU in your instance. This will make easier the installation of the NVIDIA container toolbox (covered below).
+{{% cta-primary-center "Download script for installing Docker in Ubuntu Linux" "https://raw.githubusercontent.com/social-science-data-editors/template_README/releases/README.md" %}}
 
-{{% /tip %}}
+{{% warning %}}
 
-{{% codeblock %}}
-```bash
-#1
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+Docker's set up process differs slightly accross Linux distributions, so make sure to follow the appropriate instruction for your distribution wehther it is Ubuntu, Debian or any other. If your Google cloud VM is not running in any of these distributions, check [the official Docker documentation](https://docs.docker.com/engine/install/debian/) which provides guidelines to install Docker in many different Linux distributions.
 
-#2
-$ sudo apt-get update
-
-#3
-$ sudo apt-get install \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
-
-#4
-$ sudo mkdir -p /etc/apt/keyrings
-
-#5 - Debian
-$ curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-#5 - Ubuntu
-$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-#6 - Debian
-$ echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-#6 - Ubuntu
-$ echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-#7
-$ sudo apt-get update
-
-#8
-$ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-#9
-$ sudo groupadd docker 
-
-#10
-$ sudo usermod -aG docker <your-user-name>
-
-#11
-$ newgrp docker
-
-#12
-$ docker run hello-world
-
-```
-{{% /codeblock %}}
-
-Code lines #1 to #8 from the above deal with the installation of Docker itself, while code lines #9 to #11 are in charge of allowing your user within the instance to handle Docker without security privileges being required every time you use the `docker` command (This is done by adding you username to the Docker group, for more detailed information on these instructions you can visit [the Docker website](https://docs.docker.com/engine/install/linux-postinstall/)). Finally, the last line of the code (#12 - `$ docker run hello-world`) is meant to act as a check to see if the installation was completed successfully. The command line output after running it will tell you if this was the case.
+{{% /warning %}}
 
 <p align = "center">
 <img src = "../img/output_dock_install.png" width="750">
 <figcaption> If the installation was successful the final command line output should look similar to this!</figcaption>
 </p>
 
-#### Extra! - Install the NVIDIA container toolkit (for instances including a GPU)
+{{% tip %}}
 
-If your instance includes a GPU, besides the regular [drivers](https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html#ubuntu-lts) you need to install the NVIDIA container toolkit for Docker. This toolkit is the key to allowing Docker containers within your instance to function taking full advantage of all the benefits that Google cloud machines of the GPU family offer. To carry out the installation you just need to execute the step-by-step code in the cell below, though you can also check the detailed instructions on the [NVIDIA toolkit site](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker).
+To run `docker` commands on you VM after following the Docker setup steps provided above, you will always have to do so alongside the `sudo` command. To avoid this, you can execute the code provided in the codeblock below. 
+
+{{% /tip %}}
 
 {{% codeblock %}}
 ```bash
+# Add your user to the `docker`` command group
+# to get rid of the need to `sudo` to handle Docker
 
-#1
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-      && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-      && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
-            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+usermod -aG docker your-user-name
 
-#2
-sudo apt-get update
-
-#3
-sudo apt-get install -y nvidia-docker2
-
-#4
-sudo systemctl restart docker
-
-#5
-sudo docker run --rm --gpus all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
-
+newgrp docker
 ```
 {{% /codeblock %}}
 
-<p align = "center">
-<img src = "../img/nvidia-toolkit.png" width="750">
-<figcaption> If the installation was successful you should observe something looking like in your command line this after running the code in step #5. </figcaption>
-</p>
-
-
 ### Step 2: Build the environment's image from a Dockerfile
 
-Once you have Docker installed and working, the first thing you'll need to import your environment is a [Dockerfile](https://docs.docker.com/engine/reference/builder/). A Dockerfile provides Docker with the necessary indications to produce a Docker image, each of the instances of an image is known as a container. 
+Once you have Docker successfully installed and working, the first thing you'll need to import your environment is a [Dockerfile](https://docs.docker.com/engine/reference/builder/). A Dockerfile provides Docker with the necessary indications to produce a Docker image, each of the instances of an image is known as a container. 
 
 {{% tip %}}
 
@@ -141,7 +73,7 @@ You can think of the Docker image as a template of our environment, and the Dock
 
 {{% /tip %}}
 
-First, you will need to upload your dockerfile to the instance. In Google cloud's browser SSH the easiest way to do this is to click on the "Upload file" button located close to the top right corner of the interface. There you will be able to select the files you want to upload from your local machine and these will be transferred to the instance. 
+First, you will need to upload your dockerfile to the instance. In Google Cloud's browser SSH the easiest way to do this is to click on the "Upload file" button located close to the top right corner of the interface. There you will be able to select the files you want to upload from your local machine and these will be transferred to the instance. 
 
 {{% tip %}}
 
@@ -170,7 +102,7 @@ Do not forget to include the dot at the end of the code block above as it indica
 
 {{% /warning %}}
 
-With this command, Docker will build the images and their context, the latter comprised of all the files located in the same path as your dockerfile. As a result of this, it is generally advised to place your dockerfiles in a directory with just the files it requires in to ensure the building process is as efficient as posdible. If you want to learn more about the build command and its options you can visit [this site](https://docs.docker.com/engine/reference/commandline/build/).
+With this command, Docker will build the image alongside its context, the latter comprised of all the files located in the same path as your dockerfile and which are relevant to the image. In the context of a research project whose environment is being reproduced with Docker, this would generally imply that you should place all the files which are relevant to your project's environments in the same directory as the dockerfile. However, this is highly dependant on the structure of the dockerfile and the particularities of the project. The safest approach is to follow each project's instructions on how to reproduce its environment through Docker.
 
 {{% tip %}}
  
@@ -191,9 +123,10 @@ $ docker build -t <your-image-name> .
 
 ### Step 3: Docker compose
 
-Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Additionally, it is worth noting that we could perform these actions manually by employing the `docker run` command, however in this way the process is not as straightforward.
+Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in thsi context the Docker-compose file will be in charge of the following two "services":
 
-In the same way that you needed a dockerfile to provide Docker with the necessary instructions to build an image, a docker-compose file is required to tell docker how to provide these services to a (series of) container(s).
+1. Connecting your environment's container with the rest of your system to make it posible to move files from one to the other.
+2. Launch jupyter notebook.
 
 {{% tip %}}
 
@@ -210,66 +143,22 @@ $ docker compose up
 ```
 {{% /codeblock %}}
 
- If the execution of docker-compose (and all its services) was successful that means that your environment is up and running as well as Jupyter notebook and you should see something in your command line that resembles what is shown in the image below.
+{{% tip %}}
+
+If your environment's `dockerfile` is hosted on Dockerhub you don't need to manually build it as explained in Step 2 of this building block. Instead you could just run its associated docker-compose as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it and finally executing the instructions included in the docker-compose itself.
+
+{{% /tip %}}
+
+If the execution of docker-compose was successful that means that your environment's container is up and with Jupyter notebook running. In such case and you should see something in your command line tresembling the following:
 
 <p align = "center">
 <img src = "../img/jupyter_on.png" width="750">
 <figcaption> Typical log of a Jupyter notebook instance, signaling you that the replication of the environment was completed. </figcaption>
 </p>
 
-{{% tip %}}
-
-You can also specify which services you want to run within a docker-compose file by executing the command shown above followed by the name of the service desired: `docker compose up <service-to-be-run>` .
-
-{{% /tip %}}
-
-#### Extra! - Connect the Docker container within your instance to a Google Cloud Storage bucket 
-
-Your docker-compose file likely provides Docker with the necessary instructions to employ [Docker volumes](https://docs.docker.com/storage/volumes/) to save any output file or data that you produce while working in your environment's container. If this is the case you may be also interested in connecting such volume to Google cloud storage so you don't have to manually download the output to your machine and make it easier to share and make available to your team.
-
-To do this, first of all you will need to install [GCSFuse](https://github.com/GoogleCloudPlatform/gcsfuse) in your instance by running the following code:
-
-{{% warning %}}
- 
-Carry out the following steps while your environment is not running. For that press "ctrl + c" to shut down Jupyter notebook and then run `docker compose stop` in your instance to stop the execution of the container. 
-
-{{% /warning %}}
-
-{{% codeblock %}}
-```bash
-#1
-$ export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
-echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-
-#2
-$ sudo apt-get update
-
-#3
-$ sudo apt-get install gcsfuse
-```
-{{% /codeblock %}}
-
-Now navigate to the directory of your instance which is connected to the container by the volume and create a new directory inside of it to be the one connected with your bucket. After you can run the following:
-
-{{% codeblock %}}
-```bash
-$ sudo gcsfuse -o allow_other your-bucket volume_path/new_dir/
-```
-{{% /codeblock %}}
-
-This code will tell GCSFuse to synchronize your new directory within the path with your bucket and allow your container to access it. After this, you just have to store any output produced in your environment in this new directory that you just created in your instance a few moments ago (Referred to in the previous code block as "new_dir") and it will be immediately available to you in your GCS bucket.
-
-{{% tip %}}
-
-Bear in mind that the absolute path to your bucket-sinchronized directory is not the same for your instance and for your container given that containers have independent file systems. However, its relative path will be the same to that where the Docker volume is mounted.
-
-{{% /tip %}}
-
-
 ### Step 4: Expose the port where Jupyter notebook is running to access the environment from your computer
 
-At this point, we need to make our instance accessible from the outside. The first element we need for this task is to know in which port of your instance is Jupyter notebook running. To know this we just have to take a closer look at the last line of the output shown in the command line after we executed `docker compose up`. At the begginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter notebook is running in your instance.
+At this point, you need to make the Jupyter Notebook running on your container accessible from the outside. The first element we need for this task is to know in which port of your instance is it running. To know this we just have to take a closer look at the last line of the output shown in the command line after having executed `docker compose up`. At the begginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter notebook is running in your instance.
 
 <p align = "center">
 <img src = "../img/find_port.png" width="750">
@@ -278,13 +167,13 @@ At this point, we need to make our instance accessible from the outside. The fir
 
 {{% warning %}}
 
-Note that the port in which your Jupyter notebook is running (i.e the four-digit number that corresponds to that underlined in blue in the previous image) will probably be different from the one shown in the image above.
+Note that the port in which your container's Jupyter notebook is running (i.e the four-digit number that corresponds to that underlined in blue in the previous image) will probably be different from the one shown in the image above.
 
 {{% /warning %}}
 
 {{% tip %}}
 
-You can choose in which port you want Jupyter notebook to be executed. In the context of this building block, this should be done by modifying the docker-compose, where the instructions on how Docker should set up Jupyter notebook for your environment's container are contained. [Learn more about docker-compose.](https://docs.docker.com/compose/)
+It is possible to adjust the port in which you want Jupyter notebook to be executed. In the context of this building block, this is defined by the instructions contained in the environment's docker-compose. [Learn more about docker-compose.](https://docs.docker.com/compose/)
 
 {{% /tip %}}
 
@@ -306,7 +195,7 @@ After completing the fields as described you can go to the bottom and click on "
 
 ### Step 5: Access Jupyter notebook within your environment's container
 
-To access the Jupyter notebook running inside your environment's container you have to go back to the Google cloud console list of VM instances and copy your instance's external IP direction. With this information you can open a web browser on your local computer and type the following in the URL bar: 
+To finally access the Jupyter notebook running inside your environment's container you have to go back to the Google cloud console list of virtual machine instances and copy your instance's external IP direction. With this information you can open a web browser on your local computer and type the following in the URL bar: 
  - `http://< external_ip_address >:< jupyter_port>`
 
 {{% example %}}
@@ -322,7 +211,7 @@ After introducing the url as indicated, you will be directed to your instance's 
 <figcaption> Underlined in green: The token to access Jupyter notebook. </figcaption>
 </p>
 
-As you can see in the image above, the token consists of a string of randomly generated alphanumeric characters comprising all that comes after the equal sign ("="). 
+As you can see in the image above, the token consists of a string of alphanumeric characters comprising all that comes after the equal sign ("="). 
 
 {{% warning %}}
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -1,7 +1,7 @@
 ---
-title: "Import and run a Python environment on Google cloud with Docker" 
-description: "Learn how to import a containerized python environment with docker, run it on a google cloud instance and connect it with Google cloud storage buckets"
-keywords: "Docker, environment, Python, Jupyter notebook, Google cloud, cloud computing, cloud storage "
+title: "Import and run a Project environment with Docker on Google Cloud" 
+description: "Learn how to import a containerized project environment through Docker on a Google Cloud virtual machine."
+keywords: "Docker, environment, Python, Jupyter notebook, Google Cloud, cloud ,cloud computing, cloud storage, Jupyter, docker-compose, dockerfile "
 weight: 2
 author: "Diego Sanchez Perez"
 authorlink: "https://www.linkedin.com/in/diego-s%C3%A1nchez-p%C3%A9rez-0097551b8/"
@@ -22,6 +22,12 @@ Take advantage of the versatility of containerized apps on Docker and the power 
 This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid is a general sense, its details were designed to match the particularities of the containerization process described in the preceding building block. We strongly recommend you to [visit that other building block](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a firmer understanding of the present one's content.
 
 {{% /warning %}}
+
+{{% tip %}}
+
+Cloud virtual machines offer many advantages in terms of flexibility and computational power. However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow it but employing your internal IP address (Which is typically: `127.0.0.1`) instead of the Cloud virtual machine's external IP.
+
+{{% /tip %}}
 
 ### Step 1: Install and Set up Docker in your Google cloud instance
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -15,11 +15,11 @@ aliases:
 
 ## Import and run a Python environment on Google Cloud with Docker
 
-Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Additionally, you will also learn how to run Jupyter Notebook in your cloned environment and how to access it so you can interact with the project's Python code. 
+Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Additionally, you will learn how to run Jupyter Notebook in your cloned environment and how to access it so you can interact with the project's Python code. 
 
 {{% warning %}}
 
-This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, its details were designed to match the particularities of the containerization process described in that building block. We strongly recommend you to [visit it](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a more comprehensive understanding of the present one's content and the containerization process.
+This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, their details were designed to match the particularities of the containerization process described in that building block. We strongly recommend you to [visit it](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a more comprehensive understanding of the present one's content and the containerization process.
 
 {{% /warning %}}
 
@@ -31,9 +31,9 @@ Cloud virtual machines offer many advantages in terms of flexibility and computa
 
 ### Step 1: Install and Set up Docker in your Google cloud instance
 
-Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedure for Linux-based systems. You can learn how to do so by visiting our building block on how to [set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS and Ubuntu Linux.
+Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedure for Linux-based systems. You can learn how to do so by visiting our building block on how to [set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS, and Ubuntu Linux.
 
-If you prefer to cut to the chase, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step, or save them in a shell script format file (`.sh`) to then upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with the building block.
+If you prefer to cut to the chase, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step or save them in a shell script format file (`.sh`) to then upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with the building block.
 
 {{% cta-primary-center "Script for installing Docker in Debian Linux" "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-debian.sh" %}}
 
@@ -41,7 +41,7 @@ If you prefer to cut to the chase, we have condensed these instructions into two
 
 {{% warning %}}
 
-Docker's setup process differs slightly accros Linux distributions, so make sure to follow the appropriate instructions for your distribution whether it is Ubuntu, Debian, or any other. If your Google Cloud VM is not running in any of these distributions, check [the official Docker documentation](https://docs.docker.com/engine/install/debian/) which provides guidelines for installing Docker in many different Linux distributions.
+Docker's setup process differs slightly across Linux distributions, so make sure to follow the appropriate instructions for your distribution whether it is Ubuntu, Debian, or any other. If your Google Cloud VM is not running in any of these distributions, check [the official Docker documentation](https://docs.docker.com/engine/install/debian/) which provides guidelines for installing Docker in many different Linux distributions.
 
 {{% /warning %}}
 
@@ -129,7 +129,7 @@ Docker-compose files must be YAML files, so make sure that your docker-compose f
 
 {{% /tip %}}
 
-Upload your `docker-compose.yml` in the same way you did it with your `dockerfile`, navigate to the directory where it is located and and then execute the following:
+Upload your `docker-compose.yml` in the same way you did it with your `dockerfile`, navigate to the directory where it is located and then execute the following:
 
 {{% codeblock %}}
 ```bash

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -31,7 +31,9 @@ This building block complements our previous one on [how to export project envir
 {{% tip %}}
 **Not using Virtual Machines?**
 
-Cloud virtual machines offer many advantages in terms of flexibility and computational power. However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. 
+Cloud virtual machines offer many advantages in terms of flexibility and computational power. 
+
+However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. 
 
 Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow it employing your internal IP address (Which is typically: `127.0.0.1`) instead of the cloud virtual machine's external IP.
 
@@ -41,13 +43,16 @@ Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow i
 
 Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedure for Linux-based systems. You can learn how to do so by visiting our building block on how to [set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS, and Ubuntu Linux.
 
-If you prefer to cut to the chase, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step or save them in a shell script format file (`.sh`) to then upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with the building block.
+If you prefer to cut to the chase, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines.
+
+Feel free to either follow these scripts step-by-step or save them in a shell script format file (`.sh`) to then upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with the building block.
 
 {{% cta-primary-center "Script for installing Docker in Debian Linux" "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-debian.sh" %}}
 
 {{% cta-primary-center "Script for installing Docker in Ubuntu Linux" "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-ubuntu.sh" %}}
 
 {{% warning %}}
+**Not working?**
 
 Docker's setup process differs slightly across Linux distributions, so make sure to follow the appropriate instructions for your distribution whether it is Ubuntu, Debian, or any other. If your Google Cloud VM is not running in any of these distributions, check [the official Docker documentation](https://docs.docker.com/engine/install/debian/) which provides guidelines for installing Docker in many different Linux distributions.
 
@@ -58,11 +63,7 @@ Docker's setup process differs slightly across Linux distributions, so make sure
 <figcaption> If the installation was successful the final command line output should look similar to this!</figcaption>
 </p>
 
-{{% tip %}}
-
-After completing the Docker setup steps outlined above, you'll need to prefix all Docker commands with `sudo` when running them on your VM. If you find it more convenient to bypass this requirement, you can run the following code snippet.
-
-{{% /tip %}}
+After completing the Docker setup steps outlined above, you'll need to prefix all Docker commands with `sudo` when running them on your VM. If you find it more convenient to bypass this requirement, you can run the following code snippet:
 
 {{% codeblock %}}
 ```bash
@@ -75,13 +76,18 @@ $ newgrp docker
 ```
 {{% /codeblock %}}
 
-## Step 2: Build the environment's image from a Dockerfile
+## Step 2: Build the environment's image from a `Dockerfile`
 
-After successfully installing Docker, the next step is to build your project's [dockerfile](https://docs.docker.com/engine/reference/builder/). This file provides Docker with the instructions needed to create a Docker image. To start, you'll need to transfer your project's `dockerfile` to your virtual machine. If you're using Google Cloud's browser-based SSH interface, the simplest way to do this is by clicking the 'Upload file' button, located near the top right corner of the screen. From there, you can select and upload the `dockerfile` from your local machine, and it will be transferred to your virtual machine instance.
+After successfully installing Docker, the next step is to build your project's [dockerfile](https://docs.docker.com/engine/reference/builder/). This file provides Docker with the instructions needed to create a Docker image. 
+
+To start, you'll need to transfer your project's `dockerfile` to your virtual machine. If you're using Google Cloud's browser-based SSH interface, the simplest way to do this is by clicking the 'Upload file' button, located near the top right corner of the screen. From there, you can select and upload the `dockerfile` from your local machine, and it will be transferred to your virtual machine instance.
 
 {{% tip %}}
+**Work smart, not hard**
 
-If the image of the project environment you are trying to import has been published on Docker Hub, you don't need to upload and build it manually as described. Instead you can use the [`docker pull`](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) command and Docker will automatically retrieve and build the image from Docker Hub. Then you will be ready to jump to Step 3.
+If the image of the project environment you are trying to import has been published on Docker Hub, you don't need to upload and build it manually as described. 
+
+Instead you can use the [`docker pull`](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) command and Docker will automatically retrieve and build the image from Docker Hub. Then you will be ready to jump to Step 3.
 
 {{% /tip %}}
 
@@ -99,11 +105,10 @@ $ docker build .
 ```
 {{% /codeblock %}}
 
-{{% tip %}}
+You can think of the Docker image as a template of our environment, and the dockerfile as the manual with instructions on how to build this template. 
 
-You can think of the Docker image as a template of our environment, and the dockerfile as the manual with instructions on how to build this template. This template can be used to generate containers, which can be thought of as individual instances based on the template. So, each time you tell Docker to generate a new container from the image, it generates a brand new copy of the environment from the template you previously provided.
+This template can be used to generate containers, which can be thought of as individual instances based on the template. So, each time you tell Docker to generate a new container from the image, it generates a brand new copy of the environment from the template you previously provided.
 
-{{% /tip %}}
 
 {{% warning %}}
  
@@ -114,7 +119,8 @@ Do not forget to include the dot at the end of the code block above as it indica
 With this command, Docker will build the image alongside its context, the latter comprised of all the files located in the same path as your `dockerfile` and which are relevant to the image. In the context of a research project whose environment is being reproduced with Docker, this would generally imply that you should place all the files which are relevant to your project's environments in the same directory as the `dockerfile`.
 
 {{% tip %}}
- 
+**A good practice**
+
 You can assign a name (i.e. tag) to your new Docker image by adding to the code above the flag `-t` followed by the name you want to assign in between the build command and the dot at the end as shown in the code block below. 
 
 Don't worry if you don't include this information, as in that case, Docker will automatically assign a name to the image. However, specifying a name is advisable as it will allow you to identify your images more easily.
@@ -132,16 +138,18 @@ $ docker build -t <your-image-name> .
 
 ## Step 3: Docker compose
 
-Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly and in the intended manner. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in this context, the `docker-compose` file will be in charge of the following two "services":
+Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly and in the intended manner. 
+
+These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (you can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in this context, the `docker-compose` file will be in charge of the following two "services":
 
 1. Connect your environment's container with the rest of your system to make it possible to move files from one to the other.
 2. Launch Jupyter Notebook.
 
-{{% tip %}}
+{{% warning %}}
 
 Docker-compose files must be YAML files, so make sure that your docker-compose file is denoted as such with the extension `.yml`.
 
-{{% /tip %}}
+{{% /warning %}}
 
 Upload your `docker-compose.yml` in the same way you did it with your `dockerfile`, navigate to the directory where it is located and then execute the following:
 
@@ -153,21 +161,26 @@ $ docker compose up
 {{% /codeblock %}}
 
 {{% tip %}}
+**An advantage of Docker Hub**
 
-If your environment's `dockerfile` is hosted on Dockerhub you don't need to manually build it as explained in Step 2 of this building block. Instead, you could just run its associated docker-compose file as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it, and finally executing the instructions included in the docker-compose itself.
+If your environment's `dockerfile` is hosted on Docker Hub you don't need to manually build it as explained in Step 2 of this building block. 
+
+Instead, you could just run its associated `docker-compose` file as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it, and finally executing the instructions included in the docker-compose itself.
 
 {{% /tip %}}
 
-If the execution of docker-compose was successful that means that your environment's container is up and with Jupyter Notebook running. In such case you should see something in your command line resembling the following:
+If the execution of `docker-compose` was successful that means that your environment's container is up and with Jupyter Notebook running. In such case you should see something in your command line resembling the following:
 
 <p align = "center">
 <img src = "../img/jupyter_on.png" width="750">
 <figcaption> Typical log of a Jupyter Notebook instance, signaling it is running successfully. </figcaption>
 </p>
 
-## Step 4: Expose the port where Jupyter Notebook is running to access the environment from your computer
+## Step 4: Expose the port where Jupyter Notebook is running
 
-At this point, you need to make the Jupyter Notebook running on your container accessible from the outside. The first element we need for this task is to know in which port of your instance is it running. To know this we just have to take a closer look at the last line of the output shown in the command line after having executed `docker compose up`. At the beginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter Notebook is running in your instance.
+At this point, you need to make the Jupyter Notebook running on your container accessible from the outside. The first element we need for this task is to know in which port of your instance is it running. 
+
+To know this we just have to take a closer look at the last line of the output shown in the command line after having executed `docker compose up`. At the beginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter Notebook is running in your instance.
 
 <p align = "center">
 <img src = "../img/find_port.png" width="750">
@@ -175,6 +188,7 @@ At this point, you need to make the Jupyter Notebook running on your container a
 </p>
 
 {{% warning %}}
+**Make sure**
 
 Note that the port in which your container's Jupyter notebook is running (i.e. the four-digit number that corresponds to that underlined in blue in the previous image) will probably be different from the one shown in the image above.
 
@@ -186,17 +200,18 @@ It is possible to adjust the port in which you want Jupyter Notebook to be execu
 
 {{% /tip %}}
 
-Now you should go back to the Google cloud console and click the button "Set up firewall rules" which is below your instances list. Then click again on the "Create firewall rule" option located towards the upper side of the screen. There you have to:
+Now, you should go back to the Google cloud console and click the button "Set up firewall rules" which is below your instances list. Then click again on the "Create firewall rule" option located towards the upper side of the screen. There you have to:
 
-1. Add a name of your choice for the rule (e.g. Jupyter_access_rule)
+1. Add a name of your choice for the rule (e.g. *Jupyter_access_rule*)
 2. Make sure that traffic direction is set on "Ingress"
 3. Indicate to which of your instances you want this rule to apply by selecting "Specified target tags" in the "Targets" drop-down list, and then specify the names of these in the "Target tags" box below. Alternatively, you can select the option "All instances in the network" in the drop-down menu so the rule automatically applies to all your instances. 
 4. Introduce "0.0.0.0/0" in the field "Source IPv4 ranges"
 5. In the section "Protocols and ports" check "TCP" and then in the box below introduce the four-digit number that identifies the port where Jupyter Notebook is being executed in your instance.
 
 {{% warning %}}
+**Safety first**
 
-In point three of the steps listed above you are told to introduce "0.0.0.0/0" in the field "Source IPv4 ranges". Beware this means that your instance will allow connections from any external IP (i.e. any other computer). If you are concerned about the safety risk this involves and/or you know beforehand the list of IP addresses that you want to allow to connect to your instance, you could list them here instead of typing the one-size-fits-all "0.0.0.0/0".
+In point 3 of the steps listed above you are told to introduce "0.0.0.0/0" in the field "Source IPv4 ranges". Beware this means that your instance will allow connections from any external IP (i.e. any other computer). If you are concerned about the safety risk this involves and/or you know beforehand the list of IP addresses that you want to allow to connect to your instance, you could list them here instead of typing the one-size-fits-all "0.0.0.0/0".
 
 {{% /warning %}}
 
@@ -204,8 +219,15 @@ After completing the fields as described, you can go to the bottom and click on 
 
 ## Step 5: Access Jupyter Notebook within your environment's container
 
-To finally access the Jupyter Notebook running inside your environment's container you have to go back to the Google Cloud console list of virtual machine instances and copy your instance's external IP direction. With this information, you can open a web browser on your local computer and type the following in the URL bar: 
- - `http://< external_ip_address >:< jupyter_port >`
+To finally access the Jupyter Notebook running inside your environment's container you have to go back to the Google Cloud console list of virtual machine instances and copy your instance's external IP direction. 
+
+With this information, you can open a web browser on your local computer and type the following in the URL bar:
+
+
+```
+http://< external_ip_address >:< jupyter_port >
+
+```
 
 {{% example %}}
 
@@ -235,11 +257,26 @@ Note that in the image above the token is not fully depicted. You must copy all 
 
 Now simply introduce this token in the box at the top of the landing page and click on "Log in" to access your environment.
 
-{{% tip %}}
 
-You can also paste your token in the "Token" box at the bottom of the page and generate a password with it by creating a new password in the "New Password" box. This way the next time you revisit your environment you will not need the full token, instead, you will be able to log in using your password. This is particularly useful in case you lose access to your token or this is not available to you at the moment.
+You can also paste your token in the "Token" box at the bottom of the page and generate a password with it by creating a new password in the "New Password" box. 
 
-{{% /tip %}}
+This way the next time you revisit your environment you will not need the full token, instead, you will be able to log in using your password. This is particularly useful in case you lose access to your token or this is not available to you at the moment.
+
+{{% summary %}}
+By the end of this building block, you should be able to:
+
+- **Initialize and Deploy Jupyter Notebook in Docker:** Set up a Docker environment and deploy a Jupyter Notebook using Docker Compose within a Google Cloud VM instance.
+
+- **Identify and Expose Jupyter Notebook's Port:** Locate the specific port where the Jupyter Notebook is running and configure the Google Cloud firewall settings to expose this port safely, facilitating external access.
+
+- **Access and Secure Your Jupyter Notebook:** Access the Jupyter Notebook remotely through a web browser using the VM's external IP address and port, and understand how to secure the environment using tokens or a password.
+
+{{% /summary %}}
+
+## Additional Resources
+
+- Learn how to [Configure a VM with GPUs in Google Cloud](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/config-vm-gcp/).
+- Cheat-sheat on [Docker Commands](https://docs.docker.com/get-started/docker_cheatsheet.pdf)
 
 
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -19,7 +19,7 @@ Take advantage of the versatility of containerized apps on Docker and the power 
 
 {{% warning %}}
 
-This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, its details were designed to match the particularities of the containerization process described in the preceding building block. We strongly recommend you to [visit that other building block](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a firmer understanding of the present one's content.
+This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, its details were designed to match the particularities of the containerization process described in that building block. We strongly recommend you to [visit it](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a more comprehensive understanding of the present one's content and the containerization process.
 
 {{% /warning %}}
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -14,17 +14,26 @@ aliases:
 ---
 
 ## Overview
-Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Additionally, you will learn how to run Jupyter Notebook in your cloned environment and how to access it so you can interact with the project's Python code. 
+Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! 
+
+This building block is meant to be a step-by-step guide in order for you to learn: 
+
+- How to reproduce a containerized project environment on a Google Cloud virtual machine. 
+- How to run Jupyter Notebook in your cloned environment and how to access it so you can interact with the project's Python code.
 
 {{% warning %}}
+**Good to know!**
 
-This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, their details were designed to match the particularities of the containerization process described in that building block. We strongly recommend you to [visit it](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a more comprehensive understanding of the present one's content and the containerization process.
+This building block complements our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, their details were designed to match the particularities of the containerization process described in that building block. We strongly recommend you to [visit it](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a more comprehensive understanding of the present one's content and the containerization process.
 
 {{% /warning %}}
 
 {{% tip %}}
+**Not using Virtual Machines?**
 
-Cloud virtual machines offer many advantages in terms of flexibility and computational power. However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow it employing your internal IP address (Which is typically: `127.0.0.1`) instead of the cloud virtual machine's external IP.
+Cloud virtual machines offer many advantages in terms of flexibility and computational power. However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. 
+
+Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow it employing your internal IP address (Which is typically: `127.0.0.1`) instead of the cloud virtual machine's external IP.
 
 {{% /tip %}}
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -1,5 +1,5 @@
 ---
-title: "Import and run a Project environment with Docker on Google Cloud" 
+title: "Import and run a project environment with Docker on Google Cloud" 
 description: "Learn how to import a containerized project environment through Docker on a Google Cloud virtual machine."
 keywords: "Docker, environment, Python, Jupyter notebook, Google Cloud, cloud ,cloud computing, cloud storage, Jupyter, docker-compose, dockerfile "
 weight: 2
@@ -15,25 +15,25 @@ aliases:
 
 ## Import and run a Python environment on Google Cloud with Docker
 
-Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Moreover, you will also see how to run Jupyter Notebook in your replicated environment and access to it so you can work with the project's Python code. 
+Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Additionally, you will also learn how to run Jupyter Notebook in your cloned environment and how to access it so you can interact with the project's Python code. 
 
 {{% warning %}}
 
-This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid is a general sense, its details were designed to match the particularities of the containerization process described in the preceding building block. We strongly recommend you to [visit that other building block](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a firmer understanding of the present one's content.
+This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid in a general sense, its details were designed to match the particularities of the containerization process described in the preceding building block. We strongly recommend you to [visit that other building block](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a firmer understanding of the present one's content.
 
 {{% /warning %}}
 
 {{% tip %}}
 
-Cloud virtual machines offer many advantages in terms of flexibility and computational power. However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow it but employing your internal IP address (Which is typically: `127.0.0.1`) instead of the Cloud virtual machine's external IP.
+Cloud virtual machines offer many advantages in terms of flexibility and computational power. However, if you are trying to replicate a Docker-containerized project environment in your local computer, simply follow Steps 2 and 3 of this building block and access Jupyter Notebook as you usually do. Alternatively, after Steps 2 and 3, you can jump straight to Step 5 and follow it employing your internal IP address (Which is typically: `127.0.0.1`) instead of the cloud virtual machine's external IP.
 
 {{% /tip %}}
 
 ### Step 1: Install and Set up Docker in your Google cloud instance
 
-Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedures for Linux-based systems. You can learn how to do so by visiting our building block on how to [Set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS and Ubuntu Linux.
+Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedure for Linux-based systems. You can learn how to do so by visiting our building block on how to [set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS and Ubuntu Linux.
 
-For those who prefer a more streamlined approach, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step, or save them in a shell script format file (`.sh`) to upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with this building block!
+If you prefer to cut to the chase, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step, or save them in a shell script format file (`.sh`) to then upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with the building block.
 
 {{% cta-primary-center "Script for installing Docker in Debian Linux" "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-debian.sh" %}}
 
@@ -52,46 +52,37 @@ Docker's setup process differs slightly accros Linux distributions, so make sure
 
 {{% tip %}}
 
-To run `docker` commands on your VM after following the Docker setup steps provided above, you will always have to do so alongside the `sudo` command. To avoid this, you can execute the code provided in the code block below. 
+After completing the Docker setup steps outlined above, you'll need to prefix all Docker commands with `sudo` when running them on your VM. If you find it more convenient to bypass this requirement, you can run the following code snippet.
 
 {{% /tip %}}
 
 {{% codeblock %}}
 ```bash
-# Add your user to the `docker`` command group
+# Add your user to the `docker` command group
 # to get rid of the need to `sudo` to handle Docker
 
-usermod -aG docker your-user-name
+$ usermod -aG docker your-user-name
 
-newgrp docker
+$ newgrp docker
 ```
 {{% /codeblock %}}
 
 ### Step 2: Build the environment's image from a Dockerfile
 
-Once you have Docker successfully installed and working, the first thing you'll need to import your environment is a [Dockerfile](https://docs.docker.com/engine/reference/builder/). A Dockerfile provides Docker with the necessary indications to produce a Docker image, each of the instances of an image is known as a container. 
+After successfully installing Docker, the next step is to build your project's [dockerfile](https://docs.docker.com/engine/reference/builder/). This file provides Docker with the instructions needed to create a Docker image. To start, you'll need to transfer your project's `dockerfile` to your virtual machine. If you're using Google Cloud's browser-based SSH interface, the simplest way to do this is by clicking the 'Upload file' button, located near the top right corner of the screen. From there, you can select and upload the `dockerfile` from your local machine, and it will be transferred to your virtual machine instance.
 
 {{% tip %}}
 
-You can think of the Docker image as a template of our environment, and the Dockerfile as the manual with instructions on how to build this template. This template can be used to generate containers, and containers can be thought of as instantiations (or, instances) of the template. So, each time you tell Docker to generate a new container from the image, it generates a new replica of the environment from the template you previously provided
+You can think of the Docker image as a template of our environment, and the `dockerfile` as the manual with instructions on how to build this template. This template can be used to generate containers, which can be thought of as individual instances based on the template. So, each time you tell Docker to generate a new container from the image, it generates a brand new copy of the environment from the template you previously provided.
 
 {{% /tip %}}
-
-First, you will need to upload your dockerfile to the instance. In Google Cloud's browser SSH the easiest way to do this is to click on the "Upload file" button located close to the top right corner of the interface. There you will be able to select the files you want to upload from your local machine and these will be transferred to the instance. 
-
-{{% tip %}}
-
-Recently uploaded files will be placed in your current directory at the moment of the upload
-
-{{% /tip %}}
-
 
 <p align = "center">
 <img src = "../img/upload_base.png" width="700">
 <figcaption> Locate the upload button in Google cloud's browser SSH</figcaption>
 </p>
 
-Upon having uploaded the dockerfile you can run the following code to tell Docker to build the image from it:
+Upon having uploaded the `dockerfile`, navigate to the directory where it is located and run the following code snippet to instruct Docker to build the environment's image from it:
 
 {{% codeblock %}}
 ```bash
@@ -102,17 +93,17 @@ $ docker build .
 
 {{% warning %}}
  
-Do not forget to include the dot at the end of the code block above as it indicates to Docker that it has to look for your dockerfile in the current directory.
+Do not forget to include the dot at the end of the code block above as it indicates to Docker that it has to look for your `dockerfile` in the current directory.
 
 {{% /warning %}}
 
-With this command, Docker will build the image alongside its context, the latter comprised of all the files located in the same path as your dockerfile and which are relevant to the image. In the context of a research project whose environment is being reproduced with Docker, this would generally imply that you should place all the files which are relevant to your project's environments in the same directory as the dockerfile. However, this is highly dependent on the structure of the dockerfile and the particularities of the project. The safest approach is to follow each project's instructions on how to reproduce its environment through Docker.
+With this command, Docker will build the image alongside its context, the latter comprised of all the files located in the same path as your `dockerfile` and which are relevant to the image. In the context of a research project whose environment is being reproduced with Docker, this would generally imply that you should place all the files which are relevant to your project's environments in the same directory as the `dockerfile`.
 
 {{% tip %}}
  
-You can assign a name (i.e. tag) to your new Docker image by adding to the code above the flag "-t" followed by the name you want to assign in between the build command and the dot at the end as shown in the code block below. 
+You can assign a name (i.e. tag) to your new Docker image by adding to the code above the flag `-t` followed by the name you want to assign in between the build command and the dot at the end as shown in the code block below. 
 
-Don't worry if you don't include this information as in that case, Docker will automatically assign a name to the image. However, specifying a name is advisable as it will allow you to identify your images more easily.
+Don't worry if you don't include this information, as in that case, Docker will automatically assign a name to the image. However, specifying a name is advisable as it will allow you to identify your images more easily.
 
 You can view a list of all your docker images in your Docker Desktop dashboard or by typing `docker images` in the command line.
 
@@ -127,18 +118,18 @@ $ docker build -t <your-image-name> .
 
 ### Step 3: Docker compose
 
-Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in this context, the Docker-compose file will be in charge of the following two "services":
+Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly and in the intended manner. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in this context, the `docker-compose` file will be in charge of the following two "services":
 
 1. Connect your environment's container with the rest of your system to make it possible to move files from one to the other.
-2. Launch jupyter notebook.
+2. Launch Jupyter Notebook.
 
 {{% tip %}}
 
-Docker compose files must be YAML files, so make sure that your docker-compose file is denoted as such with the extension ".yml" 
+Docker-compose files must be YAML files, so make sure that your docker-compose file is denoted as such with the extension `.yml`.
 
 {{% /tip %}}
 
-Now it is time to upload your Docker-compose in the same way you did it with your dockerfile, and then execute the following code in the directory where your docker-compose file is located:
+Upload your `docker-compose.yml` in the same way you did it with your `dockerfile`, navigate to the directory where it is located and and then execute the following:
 
 {{% codeblock %}}
 ```bash
@@ -149,7 +140,7 @@ $ docker compose up
 
 {{% tip %}}
 
-If your environment's `dockerfile` is hosted on Dockerhub you don't need to manually build it as explained in Step 2 of this building block. Instead, you could just run its associated docker-compose as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it, and finally executing the instructions included in the docker-compose itself.
+If your environment's `dockerfile` is hosted on Dockerhub you don't need to manually build it as explained in Step 2 of this building block. Instead, you could just run its associated docker-compose file as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it, and finally executing the instructions included in the docker-compose itself.
 
 {{% /tip %}}
 
@@ -195,12 +186,12 @@ In point three of the steps listed above you are told to introduce "0.0.0.0/0" i
 
 {{% /warning %}}
 
-After completing the fields as described you can go to the bottom and click on "create" to make the firewall rule effective. 
+After completing the fields as described, you can go to the bottom and click on "create" to make the firewall rule effective. 
 
 ### Step 5: Access Jupyter Notebook within your environment's container
 
 To finally access the Jupyter Notebook running inside your environment's container you have to go back to the Google Cloud console list of virtual machine instances and copy your instance's external IP direction. With this information, you can open a web browser on your local computer and type the following in the URL bar: 
- - `http://< external_ip_address >:< jupyter_port>`
+ - `http://< external_ip_address >:< jupyter_port >`
 
 {{% example %}}
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -13,8 +13,7 @@ aliases:
 
 ---
 
-## Import and run a Python environment on Google Cloud with Docker
-
+## Overview
 Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Additionally, you will learn how to run Jupyter Notebook in your cloned environment and how to access it so you can interact with the project's Python code. 
 
 {{% warning %}}
@@ -73,7 +72,7 @@ After successfully installing Docker, the next step is to build your project's [
 
 {{% tip %}}
 
-You can think of the Docker image as a template of our environment, and the `dockerfile` as the manual with instructions on how to build this template. This template can be used to generate containers, which can be thought of as individual instances based on the template. So, each time you tell Docker to generate a new container from the image, it generates a brand new copy of the environment from the template you previously provided.
+If the image of the project environment you are trying to import has been published on Docker Hub, you don't need to upload and build it manually as described. Instead you can use the [`docker pull`](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) command and Docker will automatically retrieve and build the image from Docker Hub. Then you will be ready to jump to Step 3.
 
 {{% /tip %}}
 
@@ -90,6 +89,12 @@ Upon having uploaded the `dockerfile`, navigate to the directory where it is loc
 $ docker build .
 ```
 {{% /codeblock %}}
+
+{{% tip %}}
+
+You can think of the Docker image as a template of our environment, and the dockerfile as the manual with instructions on how to build this template. This template can be used to generate containers, which can be thought of as individual instances based on the template. So, each time you tell Docker to generate a new container from the image, it generates a brand new copy of the environment from the template you previously provided.
+
+{{% /tip %}}
 
 {{% warning %}}
  

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -1,12 +1,13 @@
 ---
 title: "Import and run a project environment with Docker on Google Cloud" 
 description: "Learn how to import a containerized project environment through Docker on a Google Cloud virtual machine."
-keywords: "Docker, environment, Python, Jupyter notebook, Google Cloud, cloud ,cloud computing, cloud storage, Jupyter, docker-compose, dockerfile, Containerization, Virtual Machine"
+keywords: "Docker, environment, Python, Jupyter notebook, Google Cloud, cloud, cloud computing, cloud storage, Jupyter, docker-compose, dockerfile, Containerization, Virtual Machine"
 weight: 2
-author: "Diego Sanchez Perez"
+author: "Diego Sanchez Perez, Fernando Iscar"
 authorlink: "https://www.linkedin.com/in/diego-s%C3%A1nchez-p%C3%A9rez-0097551b8/"
 draft: false
 date: 2022-10-11T22:01:14+05:30
+updated: 2023-09-29
 aliases: 
   - /run/jupyter-on-cloud
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -1,7 +1,7 @@
 ---
 title: "Import and run a project environment with Docker on Google Cloud" 
 description: "Learn how to import a containerized project environment through Docker on a Google Cloud virtual machine."
-keywords: "Docker, environment, Python, Jupyter notebook, Google Cloud, cloud ,cloud computing, cloud storage, Jupyter, docker-compose, dockerfile "
+keywords: "Docker, environment, Python, Jupyter notebook, Google Cloud, cloud ,cloud computing, cloud storage, Jupyter, docker-compose, dockerfile, Containerization, Virtual Machine"
 weight: 2
 author: "Diego Sanchez Perez"
 authorlink: "https://www.linkedin.com/in/diego-s%C3%A1nchez-p%C3%A9rez-0097551b8/"
@@ -28,7 +28,7 @@ Cloud virtual machines offer many advantages in terms of flexibility and computa
 
 {{% /tip %}}
 
-### Step 1: Install and Set up Docker in your Google cloud instance
+## Step 1: Install and Set up Docker in your Google cloud instance
 
 Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedure for Linux-based systems. You can learn how to do so by visiting our building block on how to [set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS, and Ubuntu Linux.
 
@@ -66,7 +66,7 @@ $ newgrp docker
 ```
 {{% /codeblock %}}
 
-### Step 2: Build the environment's image from a Dockerfile
+## Step 2: Build the environment's image from a Dockerfile
 
 After successfully installing Docker, the next step is to build your project's [dockerfile](https://docs.docker.com/engine/reference/builder/). This file provides Docker with the instructions needed to create a Docker image. To start, you'll need to transfer your project's `dockerfile` to your virtual machine. If you're using Google Cloud's browser-based SSH interface, the simplest way to do this is by clicking the 'Upload file' button, located near the top right corner of the screen. From there, you can select and upload the `dockerfile` from your local machine, and it will be transferred to your virtual machine instance.
 
@@ -121,7 +121,7 @@ $ docker build -t <your-image-name> .
 ```
 {{% /codeblock %}}
 
-### Step 3: Docker compose
+## Step 3: Docker compose
 
 Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly and in the intended manner. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in this context, the `docker-compose` file will be in charge of the following two "services":
 
@@ -156,7 +156,7 @@ If the execution of docker-compose was successful that means that your environme
 <figcaption> Typical log of a Jupyter Notebook instance, signaling it is running successfully. </figcaption>
 </p>
 
-### Step 4: Expose the port where Jupyter Notebook is running to access the environment from your computer
+## Step 4: Expose the port where Jupyter Notebook is running to access the environment from your computer
 
 At this point, you need to make the Jupyter Notebook running on your container accessible from the outside. The first element we need for this task is to know in which port of your instance is it running. To know this we just have to take a closer look at the last line of the output shown in the command line after having executed `docker compose up`. At the beginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter Notebook is running in your instance.
 
@@ -193,7 +193,7 @@ In point three of the steps listed above you are told to introduce "0.0.0.0/0" i
 
 After completing the fields as described, you can go to the bottom and click on "create" to make the firewall rule effective. 
 
-### Step 5: Access Jupyter Notebook within your environment's container
+## Step 5: Access Jupyter Notebook within your environment's container
 
 To finally access the Jupyter Notebook running inside your environment's container you have to go back to the Google Cloud console list of virtual machine instances and copy your instance's external IP direction. With this information, you can open a web browser on your local computer and type the following in the URL bar: 
  - `http://< external_ip_address >:< jupyter_port >`

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker.md
@@ -13,15 +13,13 @@ aliases:
 
 ---
 
-## Import and run a Python environment on Google cloud with Docker
+## Import and run a Python environment on Google Cloud with Docker
 
-Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn how to replicate a Python environment from a project on an existing Google cloud instance using Docker and then open Jupyter notebook on it. Additionally, you will also learn how to connect your replicated environment directly to Google Cloud storage buckets to comfortably save and share your output. 
+Take advantage of the versatility of containerized apps on Docker and the power of Google Cloud to easily reproduce and collaborate on projects! In this building block, you will learn step-by-step how to reproduce a containerized project environment on a Google Cloud virtual machine. Moreover, you will also see how to run Jupyter Notebook in your replicated environment and access to it so you can work with the project's Python code. 
 
 {{% warning %}}
 
-DISCLAIMER HERE - WORK ALONGSIDE PREVIOUS BB
-
-To be able to follow this building block you will need that the project you want to import already provides both  a dockerfile and a docker-compose.yml file, with the adequate information to run the latter.
+This building block is meant to be a complement to our previous one on [how to export project environments with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/). Thus, while the steps here presented are valid is a general sense, its details were designed to match the particularities of the containerization process described in the preceding building block. We strongly recommend you to [visit that other building block](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/dockerhub/) to get a firmer understanding of the present one's content.
 
 {{% /warning %}}
 
@@ -29,15 +27,15 @@ To be able to follow this building block you will need that the project you want
 
 Google Cloud's virtual machines are configured to operate on Debian Linux by default. As a result, installing Docker on these machines follows the standard procedures for Linux-based systems. You can learn how to do so by visiting our building block on how to [Set up Docker](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/docker/), which covers the setup of Docker in Windows, MacOS and Ubuntu Linux.
 
-For those who prefer a more streamlined approach, we have condensed these instruction into two Docker installation scripts available for download below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step or directly upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with this building block!
+For those who prefer a more streamlined approach, we have condensed these instructions into two Docker installation scripts available below. These scripts work for Debian and Ubuntu Linux, which are among the most commonly used Linux distributions on Google Cloud's virtual machines. Feel free to either follow these scripts step-by-step, or save them in a shell script format file (`.sh`) to upload and execute them on your virtual machine. Either method will successfully install Docker on your VM and thus allow you to continue with this building block!
 
-{{% cta-primary-center "Download script for installing Docker in Debian Linux" "https://raw.githubusercontent.com/social-science-data-editors/template_README/releases/README.md" %}}
+{{% cta-primary-center "Script for installing Docker in Debian Linux" "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-debian.sh" %}}
 
-{{% cta-primary-center "Download script for installing Docker in Ubuntu Linux" "https://raw.githubusercontent.com/social-science-data-editors/template_README/releases/README.md" %}}
+{{% cta-primary-center "Script for installing Docker in Ubuntu Linux" "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-ubuntu.sh" %}}
 
 {{% warning %}}
 
-Docker's set up process differs slightly accross Linux distributions, so make sure to follow the appropriate instruction for your distribution wehther it is Ubuntu, Debian or any other. If your Google cloud VM is not running in any of these distributions, check [the official Docker documentation](https://docs.docker.com/engine/install/debian/) which provides guidelines to install Docker in many different Linux distributions.
+Docker's setup process differs slightly accros Linux distributions, so make sure to follow the appropriate instructions for your distribution whether it is Ubuntu, Debian, or any other. If your Google Cloud VM is not running in any of these distributions, check [the official Docker documentation](https://docs.docker.com/engine/install/debian/) which provides guidelines for installing Docker in many different Linux distributions.
 
 {{% /warning %}}
 
@@ -48,7 +46,7 @@ Docker's set up process differs slightly accross Linux distributions, so make su
 
 {{% tip %}}
 
-To run `docker` commands on you VM after following the Docker setup steps provided above, you will always have to do so alongside the `sudo` command. To avoid this, you can execute the code provided in the codeblock below. 
+To run `docker` commands on your VM after following the Docker setup steps provided above, you will always have to do so alongside the `sudo` command. To avoid this, you can execute the code provided in the code block below. 
 
 {{% /tip %}}
 
@@ -102,13 +100,13 @@ Do not forget to include the dot at the end of the code block above as it indica
 
 {{% /warning %}}
 
-With this command, Docker will build the image alongside its context, the latter comprised of all the files located in the same path as your dockerfile and which are relevant to the image. In the context of a research project whose environment is being reproduced with Docker, this would generally imply that you should place all the files which are relevant to your project's environments in the same directory as the dockerfile. However, this is highly dependant on the structure of the dockerfile and the particularities of the project. The safest approach is to follow each project's instructions on how to reproduce its environment through Docker.
+With this command, Docker will build the image alongside its context, the latter comprised of all the files located in the same path as your dockerfile and which are relevant to the image. In the context of a research project whose environment is being reproduced with Docker, this would generally imply that you should place all the files which are relevant to your project's environments in the same directory as the dockerfile. However, this is highly dependent on the structure of the dockerfile and the particularities of the project. The safest approach is to follow each project's instructions on how to reproduce its environment through Docker.
 
 {{% tip %}}
  
-You can  assign a name (i.e. tag) to your new Docker image by adding to the code above the flag "-t" followed by the name you want to assign in between the build command and the dot at the end as shown in the code block below. 
+You can assign a name (i.e. tag) to your new Docker image by adding to the code above the flag "-t" followed by the name you want to assign in between the build command and the dot at the end as shown in the code block below. 
 
-Don't worry if you don't include this information as in that case Docker will automatically assign a name to the image. However, specifying a name is advisable as it will allow you to identify your images more easily.
+Don't worry if you don't include this information as in that case, Docker will automatically assign a name to the image. However, specifying a name is advisable as it will allow you to identify your images more easily.
 
 You can view a list of all your docker images in your Docker Desktop dashboard or by typing `docker images` in the command line.
 
@@ -123,9 +121,9 @@ $ docker build -t <your-image-name> .
 
 ### Step 3: Docker compose
 
-Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in thsi context the Docker-compose file will be in charge of the following two "services":
+Docker compose is a tool within the Docker ecosystem whose main functionality is to coordinate your containers and provide them with the services required to run smoothly. These services include actions such as communication between containers or starting up containers that require additional instructions to do so. Although this can sound a bit confusing if you are new to Docker (You can learn more about Docker compose [here](https://docs.docker.com/compose/)), the key takeaway is that it will assist and simplify the task of replicating your environment by providing some extra information to Docker about how to do so. Particularly, in this context, the Docker-compose file will be in charge of the following two "services":
 
-1. Connecting your environment's container with the rest of your system to make it posible to move files from one to the other.
+1. Connect your environment's container with the rest of your system to make it possible to move files from one to the other.
 2. Launch jupyter notebook.
 
 {{% tip %}}
@@ -145,20 +143,20 @@ $ docker compose up
 
 {{% tip %}}
 
-If your environment's `dockerfile` is hosted on Dockerhub you don't need to manually build it as explained in Step 2 of this building block. Instead you could just run its associated docker-compose as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it and finally executing the instructions included in the docker-compose itself.
+If your environment's `dockerfile` is hosted on Dockerhub you don't need to manually build it as explained in Step 2 of this building block. Instead, you could just run its associated docker-compose as shown above and Docker will take care of the rest automatically, pulling the image from Dockerhub, building it, and finally executing the instructions included in the docker-compose itself.
 
 {{% /tip %}}
 
-If the execution of docker-compose was successful that means that your environment's container is up and with Jupyter notebook running. In such case and you should see something in your command line tresembling the following:
+If the execution of docker-compose was successful that means that your environment's container is up and with Jupyter Notebook running. In such case you should see something in your command line resembling the following:
 
 <p align = "center">
 <img src = "../img/jupyter_on.png" width="750">
-<figcaption> Typical log of a Jupyter notebook instance, signaling you that the replication of the environment was completed. </figcaption>
+<figcaption> Typical log of a Jupyter Notebook instance, signaling it is running successfully. </figcaption>
 </p>
 
-### Step 4: Expose the port where Jupyter notebook is running to access the environment from your computer
+### Step 4: Expose the port where Jupyter Notebook is running to access the environment from your computer
 
-At this point, you need to make the Jupyter Notebook running on your container accessible from the outside. The first element we need for this task is to know in which port of your instance is it running. To know this we just have to take a closer look at the last line of the output shown in the command line after having executed `docker compose up`. At the begginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter notebook is running in your instance.
+At this point, you need to make the Jupyter Notebook running on your container accessible from the outside. The first element we need for this task is to know in which port of your instance is it running. To know this we just have to take a closer look at the last line of the output shown in the command line after having executed `docker compose up`. At the beginning of the line, you should see an address like the one shown below, from there you are interested in the four digits underlined in blue coming after the internal IP and before the slash. These correspond with the port where Jupyter Notebook is running in your instance.
 
 <p align = "center">
 <img src = "../img/find_port.png" width="750">
@@ -167,13 +165,13 @@ At this point, you need to make the Jupyter Notebook running on your container a
 
 {{% warning %}}
 
-Note that the port in which your container's Jupyter notebook is running (i.e the four-digit number that corresponds to that underlined in blue in the previous image) will probably be different from the one shown in the image above.
+Note that the port in which your container's Jupyter notebook is running (i.e. the four-digit number that corresponds to that underlined in blue in the previous image) will probably be different from the one shown in the image above.
 
 {{% /warning %}}
 
 {{% tip %}}
 
-It is possible to adjust the port in which you want Jupyter notebook to be executed. In the context of this building block, this is defined by the instructions contained in the environment's docker-compose. [Learn more about docker-compose.](https://docs.docker.com/compose/)
+It is possible to adjust the port in which you want Jupyter Notebook to be executed. In the context of this building block, this is defined by the instructions contained in the environment's docker-compose. [Learn more about docker-compose.](https://docs.docker.com/compose/)
 
 {{% /tip %}}
 
@@ -183,7 +181,7 @@ Now you should go back to the Google cloud console and click the button "Set up 
 2. Make sure that traffic direction is set on "Ingress"
 3. Indicate to which of your instances you want this rule to apply by selecting "Specified target tags" in the "Targets" drop-down list, and then specify the names of these in the "Target tags" box below. Alternatively, you can select the option "All instances in the network" in the drop-down menu so the rule automatically applies to all your instances. 
 4. Introduce "0.0.0.0/0" in the field "Source IPv4 ranges"
-5. In the section "Protocols and ports" check "TCP" and then in the box below introduce the four-digit number that identifies the port where Jupyter notebook is being executed in your instance.
+5. In the section "Protocols and ports" check "TCP" and then in the box below introduce the four-digit number that identifies the port where Jupyter Notebook is being executed in your instance.
 
 {{% warning %}}
 
@@ -193,9 +191,9 @@ In point three of the steps listed above you are told to introduce "0.0.0.0/0" i
 
 After completing the fields as described you can go to the bottom and click on "create" to make the firewall rule effective. 
 
-### Step 5: Access Jupyter notebook within your environment's container
+### Step 5: Access Jupyter Notebook within your environment's container
 
-To finally access the Jupyter notebook running inside your environment's container you have to go back to the Google cloud console list of virtual machine instances and copy your instance's external IP direction. With this information you can open a web browser on your local computer and type the following in the URL bar: 
+To finally access the Jupyter Notebook running inside your environment's container you have to go back to the Google Cloud console list of virtual machine instances and copy your instance's external IP direction. With this information, you can open a web browser on your local computer and type the following in the URL bar: 
  - `http://< external_ip_address >:< jupyter_port>`
 
 {{% example %}}
@@ -204,11 +202,11 @@ Imagine the external IP of your instance is "12.345.678.9" and the port where Ju
 
 {{% /example %}}
 
-After introducing the url as indicated, you will be directed to your instance's Jupyter notebook landing page. Here Jupyter will request you a token to grant you access. This token can be found in the same output line of your google cloud instance's command line where you look at the port where Jupyter is being run.
+After introducing the URL as indicated, you will be directed to your instance's Jupyter Notebook landing page. Here Jupyter will request you a token to grant you access. This token can be found in the same output line of your Google Cloud instance's command line where you look at the port where Jupyter is being run.
 
 <p align = "center">
 <img src = "../img/find_token.png" width="750">
-<figcaption> Underlined in green: The token to access Jupyter notebook. </figcaption>
+<figcaption> Underlined in green: The token to access Jupyter Notebook. </figcaption>
 </p>
 
 As you can see in the image above, the token consists of a string of alphanumeric characters comprising all that comes after the equal sign ("="). 
@@ -228,7 +226,7 @@ Now simply introduce this token in the box at the top of the landing page and cl
 
 {{% tip %}}
 
-You can also paste your token  in the "Token" box at the bottom of the page and generate a password with it by creating a new password in the "New Password" box. This way the next time you revisit your environment you will not need the full token, instead, you will be able to login using your password. This is particularly useful in case you lose access to your token or this is not available to you at the moment.
+You can also paste your token in the "Token" box at the bottom of the page and generate a password with it by creating a new password in the "New Password" box. This way the next time you revisit your environment you will not need the full token, instead, you will be able to log in using your password. This is particularly useful in case you lose access to your token or this is not available to you at the moment.
 
 {{% /tip %}}
 

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-debian.sh
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-debian.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Check if the script is being run as a superuser
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run the script as superuser (root)"
+  exit 1
+fi
+
+# Step 1: Remove previous versions of Docker
+apt-get remove -y docker docker-engine docker.io containerd runc
+
+# Step 2: Update the package list
+apt-get update
+
+# Step 3: Install dependencies
+apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+# Step 4: Create directory for Docker key
+mkdir -p /etc/apt/keyrings
+
+# Step 5: Add Docker GPG key
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Step 6: Add Docker repository
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Step 7: Update the package list again
+apt-get update
+
+# Step 8: Install Docker
+apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Step 9: Add Docker group if it doesn't exist
+if ! getent group docker > /dev/null; then
+    groupadd docker
+fi
+
+# Step 10: Add user to Docker group
+# This step is commented out to be manually executed if necessary
+# usermod -aG docker <your-user-name>
+
+# Step 11: Activate group changes
+# This step is commented out to be manually executed if necessary
+# newgrp docker
+
+# Step 12: Verify Docker installation
+docker run hello-world
+
+echo "Docker installation complete."

--- a/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-ubuntu.sh
+++ b/content/building-blocks/automate-and-execute-your-work/reproducible-work/install-docker-ubuntu.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Check if the script is being run as a superuser
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run the script as superuser (root)"
+  exit 1
+fi
+
+# Step 1: Remove previous versions of Docker
+apt-get remove -y docker docker-engine docker.io containerd runc
+
+# Step 2: Update the package list
+apt-get update
+
+# Step 3: Install dependencies
+apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+# Step 4: Create directory for Docker key
+mkdir -p /etc/apt/keyrings
+
+# Step 5: Add Docker GPG key
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Step 6: Add Docker repository
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Step 7: Update the package list again
+apt-get update
+
+# Step 8: Install Docker
+apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Step 9: Add Docker group if it doesn't exist
+if ! getent group docker > /dev/null; then
+    groupadd docker
+fi
+
+# Step 10: Add user to Docker group
+# This step is commented out to be manually executed if necessary
+# usermod -aG docker <your-user-name>
+
+# Step 11: Activate group changes
+# This step is commented out to be manually executed if necessary
+# newgrp docker
+
+# Step 12: Verify Docker installation
+docker run hello-world
+
+echo "Docker installation complete."


### PR DESCRIPTION
This pull request contains a series of updates for the building block [Import and run a Python environment on Google cloud with Docker](https://tilburgsciencehub.com/building-blocks/automate-and-execute-your-work/reproducible-work/google_cloud_docker/).

The updates proposed in this PR go beyond the original scope of the summer sprint tasks assigned to Issue https://github.com/tilburgsciencehub/website/issues/743. @Fernando-Iscar and I have been collaborating to reformulate some segments of the Docker and GCloud building blocks to improve their connections, structure and content distribution within the context of the summer sprint issues but going a bit further in terms of the updates proposed.

