### PR TITLE
Fix bug page blogpost TOSS not loading

### DIFF
--- a/content/blog/TOSS_presentation.md
+++ b/content/blog/TOSS_presentation.md
@@ -28,4 +28,4 @@ Our presentation didn't end at Docker. We also introduced a new concept to the a
 To conclude our presentation, we emphasized that Tilburg Science Hub extends beyond Docker. We offer a comprehensive toolkit that covers everything from data collection and analysis to version control. Our platform fosters simplicity, clarity, and transparency in research.
 
 ### **Explore Our Presentation Slides**
-To delve deeper into the tools and concepts we presented, we invite you to explore our [presentation slides](TOSS_presentation.pptx). 
+To delve deeper into the tools and concepts we presented, we invite you to explore our [presentation slides](TOSS_presentation_slides.pptx). 


### PR DESCRIPTION
Hi Hannes,

The new blogpost keeped loading for hours and was not viewable on the site. I think this might be the case because the md and pptx file had the same name and therefore this was not working: 
aliases:
  - /blog/TOSS_presentation

I changed the name of the pptx file and hope it is visible now on the site if merged.