### PR TITLE
Fix for issue #894 (recently updated articles in cards)

### DIFF
--- a/themes/tilburg/layouts/index.html
+++ b/themes/tilburg/layouts/index.html
@@ -280,7 +280,7 @@
               {{ $s := slice }}
               {{ $displayedTitles := dict }}
 
-              {{ range where .Site.Pages.ByPublishDate.Reverse "Section" "in" "[building-blocks, tutorials]" }}
+              {{ range where .Site.Pages.ByLastmod.Reverse "Section" "in" "[building-blocks, tutorials]" }}
               {{ $title := .Title }}
               {{ if not (index $displayedTitles $title) }}
               {{ $s = $s | append . }}
@@ -288,7 +288,7 @@
               {{ end }}
               {{ end }}
 
-              {{ with $s.ByPublishDate.Reverse | first 3 }}
+              {{ with $s.ByLastmod.Reverse | first 3 }}
               {{ range . }}
               <li class="pb-3">
                 <span class="icon link text-primary d-inline-block mr-2"></span>


### PR DESCRIPTION
@hannesdatta I invested quite some time in investigating into this issue, almost all fora had wrong advices and ChatGPT also could not solve it. I tried it using a quite recent command called Lastmod from Hugo. It should take the files that have been modified most recently. This is the only workaround I could think of within Hugo, since we publish new articles and also modify articles. I hope this function works as expected, but we can only know for sure after implementing and testing.