### PR TITLE
Link to tilburg.ai

### DIFF
--- a/themes/tilburg/layouts/index.html
+++ b/themes/tilburg/layouts/index.html
@@ -305,11 +305,11 @@
           <div class="h-100 p-3 rounded bg-white d-flex justify-content-center align-items-center">
             <div>
               <h2 class="text-center heading px-3" style="font-size: 20px ; line-height: 1 !important">
-                Use our code snippets in your projects
+                Explore how to use AI tools
               </h2>
               <div class="text-center mt-4 mb-0">
-                <a href="/building-blocks/">
-                  <button class="btn tertiary ">Use a code snippet</button>
+                <a href="https://tilburg.ai">
+                  <button class="btn tertiary ">Visit tilburg.ai</button>
                 </a>
               </div>
             </div>


### PR DESCRIPTION
For SEO purposes, link to tilburg.ai from the landing page. also to cross-link content.