### PR TITLE
Fix broken data link modelsummary

### DIFF
--- a/content/topics/Visualization/data-visualization/regression-results/model-summary.md
+++ b/content/topics/Visualization/data-visualization/regression-results/model-summary.md
@@ -49,7 +49,8 @@ library(stringr)
 
 
 # Load data
-data_url <- "https://github.com/tilburgsciencehub/website/blob/master/content/topics/Visualization/Data_visualization/Regression_results/data_rent.Rda?raw=true"
+data_url <- "https://raw.githubusercontent.com/tilburgsciencehub/website/master/content/topics/Visualization/data-visualization/regression-results/data_rent.Rda"
+
 load(url(data_url)) #data_rent is the cleaned data set
 ```
 {{% /codeblock %}}


### PR DESCRIPTION
The link for loading the data in the R code did not work anymore, so I fixed it in this PR.