### PR TITLE
Fix duplicate contributions on the contributors page

### DIFF
--- a/themes/tilburg/layouts/contributors/single.html
+++ b/themes/tilburg/layouts/contributors/single.html
@@ -29,7 +29,7 @@
 							<!-- Get Contributions -->
 							{{ $contributions := slice }}
 
-							{{ range where .Site.Pages "Section" "topics" }}
+					        {{ range where .Site.Pages "Section" "topics" }}
 							{{ if ne .Title "topics" }}
 							{{ if isset .Params "author" }}
 							{{ if eq .Params.Author $.Params.name }}
@@ -37,17 +37,8 @@
 							{{ end }}
 							{{ end }}
 							{{ end }}
-							{{ end }}
+							{{ end }} 
 
-							{{ range where .Site.Pages "Section" "topics" }}
-							{{ if ne .Title "tutorials" }}
-							{{ if isset .Params "author" }}
-							{{ if eq .Params.Author $.Params.name }}
-							{{ $contributions = $contributions | append . }}
-							{{ end }}
-							{{ end }}
-							{{ end }}
-							{{ end }}
 
 							{{ range where .Site.Pages "Section" "examples" }}
 							{{ if ne .Title "examples" }}
@@ -58,9 +49,10 @@
 							{{ end }}
 							{{ end }}
 							{{ end }}
-
+						
 							{{ with $contributions }}
-							<p class="mb-0"><strong style="font-weight: 700;">Contributions:</strong></p>
+							
+							<p class="mb-0"><strong style="font-weight: 700;">Contributions:</strong></p>		
 							<ul style="padding-inline-start: 20px;">
 								{{ range $contributions }}
 								<li style="color: #013365;"><a href="{{ .Permalink }}" style="color:inherit">{{ .Title }}</a></li>


### PR DESCRIPTION
The reason why there were duplicates is that there were 2 loops that had the same first IF condition, they were checking pages in the section "topics". In the second condition, one of them checks again if the title is not equal to "topics" and the other one to "tutorials". The problem is that I could not find a section called "tutorials", is there one? Since the second condition for both loops is true, both of them were collecting the same contributions, and as a result, there were duplicates.

Please see the removed loop from lines 42 to 50. As mentioned above, there is no section "tutorials". Removing it removes duplicates. 

