### PR TITLE
Fix non-parametric tests section

### DIFF
--- a/content/topics/Analyze/Non-parametric-tests/tests/_index.md
+++ b/content/topics/Analyze/Non-parametric-tests/tests/_index.md
@@ -1,5 +1,5 @@
 ---
 draft: false
-title: "Tests"
+title: "Non-parametric Tests"
 weight: 1
 ---


### PR DESCRIPTION
Hi @lachlandeer, 

I noticed the 3 non-parametric test topics were not showing on the website, although published. This was because an index file was missing, now they do show. I also switched the section names as "Tests" was the smaller section within "Non-parametric Tests", let me know if this is correct!
