### PR TITLE
Check for multiple authors on the contributors page

### DIFF
--- a/themes/tilburg/layouts/contributors/single.html
+++ b/themes/tilburg/layouts/contributors/single.html
@@ -36,8 +36,8 @@
 							{{ $match := false }}
 							{{ range $names }}
 								{{ if eq . $.Params.name }}
-										{{ $match = true }}
-									{{ end }}
+									{{ $match = true }}
+								{{ end }}
 								{{ end }}
 								{{ if $match }}
 									{{ $contributions = $contributions | append . }}
@@ -54,8 +54,8 @@
 							{{ $match := false }}
 							{{ range $names }}
 								{{ if eq . $.Params.name }}
-										{{ $match = true }}
-									{{ end }}
+									{{ $match = true }}
+								{{ end }}
 								{{ end }}
 								{{ if $match }}
 									{{ $contributions = $contributions | append . }}

--- a/themes/tilburg/layouts/contributors/single.html
+++ b/themes/tilburg/layouts/contributors/single.html
@@ -38,7 +38,7 @@
 								{{ if eq . $.Params.name }}
 									{{ $match = true }}
 								{{ end }}
-								{{ end }}
+							{{ end }}
 								{{ if $match }}
 									{{ $contributions = $contributions | append . }}
 								{{ end }}
@@ -56,7 +56,7 @@
 								{{ if eq . $.Params.name }}
 									{{ $match = true }}
 								{{ end }}
-								{{ end }}
+							{{ end }}
 								{{ if $match }}
 									{{ $contributions = $contributions | append . }}
 								{{ end }}

--- a/themes/tilburg/layouts/contributors/single.html
+++ b/themes/tilburg/layouts/contributors/single.html
@@ -29,23 +29,37 @@
 							<!-- Get Contributions -->
 							{{ $contributions := slice }}
 
-					        {{ range where .Site.Pages "Section" "topics" }}
+							{{ range where .Site.Pages "Section" "topics" }}	
 							{{ if ne .Title "topics" }}
 							{{ if isset .Params "author" }}
-							{{ if eq .Params.Author $.Params.name }}
-							{{ $contributions = $contributions | append . }}
+							{{ $names := split .Params.Author ", " }}
+							{{ $match := false }}
+							{{ range $names }}
+								{{ if eq . $.Params.name }}
+										{{ $match = true }}
+									{{ end }}
+								{{ end }}
+								{{ if $match }}
+									{{ $contributions = $contributions | append . }}
+								{{ end }}
 							{{ end }}
 							{{ end }}
 							{{ end }}
-							{{ end }} 
 
-
-							{{ range where .Site.Pages "Section" "examples" }}
+							
+							{{ range where .Site.Pages "Section" "examples" }}	
 							{{ if ne .Title "examples" }}
 							{{ if isset .Params "author" }}
-							{{ if eq .Params.Author $.Params.name }}
-							{{ $contributions = $contributions | append . }}
-							{{ end }}
+							{{ $names := split .Params.Author ", " }}
+							{{ $match := false }}
+							{{ range $names }}
+								{{ if eq . $.Params.name }}
+										{{ $match = true }}
+									{{ end }}
+								{{ end }}
+								{{ if $match }}
+									{{ $contributions = $contributions | append . }}
+								{{ end }}
 							{{ end }}
 							{{ end }}
 							{{ end }}


### PR DESCRIPTION
As mentioned in the issue #1148 when there are multiple authors for an article, they did not show up on the contributor page. 
Therefore, on the contributor's page when we try to read authors' names now we need to check if a coma appears and if so, check that contributor's name is there.
