### PR TITLE
fix links to building block and tutorial markdown templates

### DIFF
--- a/content/topics/Collaborate-share/Project-management/engage-open-science/contribute-to-tilburg-science-hub/pullrequests.md
+++ b/content/topics/Collaborate-share/Project-management/engage-open-science/contribute-to-tilburg-science-hub/pullrequests.md
@@ -144,9 +144,9 @@ First, make sure to read our [code of conduct](../code-of-conduct) as well as ou
 
 {{% /warning %}}
 
-{{% cta-primary "Start with our Building Block Markdown template" "https://raw.githubusercontent.com/tilburgsciencehub/tsh-website/master/content/topics/more-tutorials/contribute-to-tilburg-science-hub/building-block-shell.md" %}}
+{{% cta-primary "Start with our Building Block Markdown template" "https://raw.githubusercontent.com/tilburgsciencehub/tsh-website/master/content/topics/Collaborate-share/Project-management/engage-open-science/contribute-to-tilburg-science-hub/building-block-shell.md" %}}
 
-{{% cta-primary "Start with our Tutorial Markdown template" "https://raw.githubusercontent.com/tilburgsciencehub/tsh-website/master/content/topics/more-tutorials/contribute-to-tilburg-science-hub/tutorial-shell.md" %}}
+{{% cta-primary "Start with our Tutorial Markdown template" "https://raw.githubusercontent.com/tilburgsciencehub/tsh-website/master/content/topics/Collaborate-share/Project-management/engage-open-science/contribute-to-tilburg-science-hub/tutorial-shell.md" %}}
 
 
 <!--


### PR DESCRIPTION
Reported by @gbocsardi in issue #1199 . The links were not correct for both templates. I have corrected them. 

