### PR TITLE
Add aliases statistical power

### DIFF
--- a/content/topics/Analyze/causal-inference/introduction/statistical-power.md
+++ b/content/topics/Analyze/causal-inference/introduction/statistical-power.md
@@ -5,6 +5,9 @@ keywords: "statistical power, causal, inference, effect, power analysis, R, samp
 draft: false
 weight: 2
 author: "Victor Arutyunov"
+aliases:
+  - /statistical-power
+  - /power
 ---
 
 ## Introduction 


### PR DESCRIPTION
Small fix, so I can refer to this statistical power article using the alias.