### PR TITLE
Add missing dates to Virginias article

### DIFF
--- a/content/topics/Analyze/causal-inference/synthetic-control/intro-synthetic-control.md
+++ b/content/topics/Analyze/causal-inference/synthetic-control/intro-synthetic-control.md
@@ -4,6 +4,7 @@ description: "This article provides an introduction to synthetic control methods
 keywords: "causal, inference, econometrics, model, treatment, effect, control, synthetic"
 draft: false
 weight: 1
+date: 2024-09-01T01:00:00+01:00
 author: "Virginia Mirabile"
 ---
 

--- a/content/topics/Analyze/causal-inference/synthetic-control/synthetic_control_exog.md
+++ b/content/topics/Analyze/causal-inference/synthetic-control/synthetic_control_exog.md
@@ -4,6 +4,7 @@ description: "This article illustrates how to perform causal inference with synt
 keywords: "causal, inference, econometrics, model, treatment, effect, control, synthetic, exogenous"
 draft: false
 weight: 1
+date: 2024-09-01T01:00:00+01:00
 author: "Virginia Mirabile"
 ---
 


### PR DESCRIPTION
There were missing dates in Virginia's articles and because of that they were not displayed on the website since they were not parsed correctly into the database