### PR TITLE
Fix Katex using CDN

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -32,45 +32,28 @@
 	</script>
 	<!--snippet for google optimize (A/B tests) put back on when needed 
 	<script async src="https://www.googleoptimize.com/optimize.js?id=OPT-N42NQJS"></script>-->
-
-	<!-- Katex -->
-	<script>
-		// Controleer of de URL 'topics' bevat
-		if (window.location.href.includes('topics')) {
-			// Als 'topics' in de URL staat, laad de CSS direct
-			var link = document.createElement("link");
-			link.rel = "stylesheet";
-			link.href = "{{ url_for('static', filename='katex/katex.min.css') }}";
-			document.head.appendChild(link);
-
-			// Laad de KaTeX JavaScript-bestanden
-			var script1 = document.createElement("script");
-			script1.src = "{{ url_for('static', filename='katex/katex.min.js') }}";
-			script1.defer = true;
-			document.head.appendChild(script1);
-
-			var script2 = document.createElement("script");
-			script2.src = "{{ url_for('static', filename='katex/auto-render.min.js') }}";
-			script2.defer = true;
-			document.head.appendChild(script2);
-
-			var script3 = document.createElement("script");
-			script3.src = "{{ url_for('static', filename='katex/auto-render.min.js') }}";
-			script3.defer = true;
-			script3.onload = function() {
-				renderMathInElement(document.body, {
-					delimiters: [
-						{left: '$$', right: '$$', display: true},
-						{left: '\\[', right: '\\]', display: true},
-						{left: '$', right: '$', display: false},
-						{left: '\\(', right: '\\)', display: false}
-					]
-				});
-			};
-			document.head.appendChild(script3);
-		}
-	</script>
 	
+	<!-- Include KaTeX CSS -->
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css">
+
+	<!-- Include KaTeX JS -->
+	<script src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js"></script>
+
+	<!-- Include Auto-render -->
+	<script src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/contrib/auto-render.min.js"> </script>
+	
+	<script>
+		document.addEventListener("DOMContentLoaded", function () {
+		  renderMathInElement(document.body, {
+			delimiters: [
+			  { left: "$$", right: "$$", display: true }, // Block math
+			  { left: "$", right: "$", display: false }, // Block math
+			  { left: "\\(", right: "\\)", display: false } // Inline math
+			]
+		  });
+		});
+	  </script>
+		
 	<!-- Common Meta Data -->
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
@@ -96,6 +79,8 @@
 	<!-- Styling and scripts-->
 	<link rel="stylesheet" href="{{ assets['scss_all'].urls()[0] }}">
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+	
+	<script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.12"></script>
 	
 	<link rel=stylesheet href=https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css>
 


### PR DESCRIPTION
Before we were rendering Katex by using `auto-render.min.js`, `katex.min.js` and `katex.min.css` from the static folder. 
However, that didnt seem to be very reliable. Using Content Deliver Network should work just fine.